### PR TITLE
Add: SaneClip

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,7 @@
 - [Maccy](https://maccy.app) - Minimal clipboard manager. 🍎 🟢
 - [Parcellite](https://parcellite.sourceforge.io) - Basic clipboard manager. 🐧
 - [Qopy](https://github.com/0pandadev/qopy) - Minimalist clipboard manager with unique features. 🪟 🍎 🐧 🟢
+- [SaneClip](https://saneclip.com) - Clipboard manager that keeps all history local with search and formatting tools. 🍎 [🟢](https://github.com/sane-apps/SaneClip)
 
 ### Metadata
 


### PR DESCRIPTION
Adding SaneClip to Clipboard Management.

SaneClip is a macOS clipboard manager that keeps all clipboard history stored locally on your device. No cloud sync, no telemetry, no account required. Free with optional Pro upgrade.

- Website: https://saneclip.com
- Source: https://github.com/sane-apps/SaneClip (PolyForm Shield — open source for personal use)

Disclosure: I am the developer of SaneClip.