### PR TITLE
Add: SaneHosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,10 @@
 - [RoboForm](https://roboform.com) - Password manager and form filler with multi-platform synchronization. 🪟 🍎 🐧
 - [ProtonPass](https://proton.me/pass) - Free password manager with end-to-end encryption based in Switzerland. 🪟 🍎 🐧 [🟢](https://github.com/protonpass)
 
+### Ad & Tracker Blocking
+
+- [SaneHosts](https://sanehosts.com) - macOS hosts file manager for system-wide ad and tracker blocking. 🍎 [🟢](https://github.com/sane-apps/SaneHosts)
+
 ## Image Viewers
 
 - [ImageGlass](https://imageglass.org) - Lightweight, versatile image viewer. 🪟 🟢 ⭐


### PR DESCRIPTION
Adding SaneHosts to Security under a new "Ad & Tracker Blocking" subsection.

SaneHosts is a macOS hosts file manager for system-wide ad and tracker blocking via /etc/hosts. No telemetry, no account required. Free with optional Pro upgrade.

There's currently no ad/tracker blocking category under Security — SaneHosts is the first entry. Happy to adjust placement if you'd prefer a different section.

- Website: https://sanehosts.com
- Source: https://github.com/sane-apps/SaneHosts (PolyForm Shield — open source for personal use)

Disclosure: I am the developer of SaneHosts.