### PR TITLE
Add HeyRobyn - Native Mac unified inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@
 - [Eppie Mail](https://github.com/Eppie-io/Eppie-App) - Open-source email client with local AI agents and full support for Gmail, Outlook, and Proton Mail. 🪟 🍎 🐧 🟢
 - [eM Client](https://emclient.com) - Modern client to boost your productivity. 🪟
 - [Foxmail](https://www.foxmail.com) - Fast, user-friendly email client. 🪟 🍎
+- [HeyRobyn](https://heyrobyn.ai) - Native Mac unified inbox for email, Slack, and GitHub in one window. 🍎
 - [Mailbird](https://mailbird.com) - IMAP/POP3 client with customization options. 🪟
 - [Mailspring](https://getmailspring.com) - Beautiful, fast email client. 🪟 🍎 🐧 🟢
 - [Nylas Mail](https://nylas.com/nylas-mail) - Extensible desktop email app based on web technologies. 🪟 🍎 🐧


### PR DESCRIPTION
Hi! 👋

I'd like to add **HeyRobyn** to the Email Clients section.

**What is HeyRobyn?**
HeyRobyn is a native macOS unified inbox that combines email, Slack, and GitHub notifications into one window. Built with SwiftUI for optimal performance, it's designed for Mac power users who need to manage multiple communication channels efficiently.

**Key features:**
- ✅ Native macOS app (SwiftUI, not Electron)
- ✅ Unified inbox for email, Slack, and GitHub
- ✅ Privacy-first with all data stored on-device
- ✅ Free tier available

**Website:** https://heyrobyn.ai

The app fits naturally in the Email Clients section as it extends traditional email client functionality to include modern workplace communication tools (Slack, GitHub).

Thanks for maintaining this awesome list!