### PR TITLE
Add: HeyRobyn

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@
 - [Spark](https://sparkmailapp.com) - Fast email client with team collaboration features. 🍎 🐧
 - [ThunderBird](https://thunderbird.net) - Email client for easier management. 🪟 🍎 🐧 🟢
 - [Tutanota](https://tutanota.com) - Encrypted service focused on privacy. 🪟 🍎 🐧
+- [HeyRobyn](https://heyrobyn.ai) - Native Mac unified inbox for email, Slack, and GitHub in one window. 🍎
 
 ## Compression and Archiving
 


### PR DESCRIPTION
# Add HeyRobyn to Email Clients

**HeyRobyn** is a native Mac unified inbox that combines email, Slack, and GitHub in one window.

## Details:
- **Category**: Communication > Email Clients
- **Position**: Added to bottom of section (per contribution guidelines)
- **Description**: Native Mac unified inbox for email, Slack, and GitHub in one window.
- **Platform**: 🍎 (macOS only)

Following the contribution guidelines:
✓ App added to bottom of category
✓ Description is short and highlights key features
✓ Description ends with period
✓ No "A", "An", "The" prefix
✓ Commit message follows format "Add: HeyRobyn"

Website: https://heyrobyn.ai

Thank you for maintaining this excellent resource!