### PR TITLE
Add: PDFGem, Vizua

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@
 - [Xournal++](https://xournalpp.github.io) - Handwriting and annotation tool for PDFs. 🪟 🍎 🐧 [🟢](https://github.com/xournalpp/xournalpp)
 - [PDFGear](https://www.pdfgear.com) - Read, edit, convert, merge, and sign PDF files across devices. 🪟 🍎
 - [PDFsam](https://pdfsam.org) - Extract pages, split, merge, mix and rotate PDF files. 🪟 🍎 🐧 [🟢](https://github.com/torakiki/pdfsam)
-- [PDFGem](https://pdfgem.io) - Browser-based PDF tools to merge, split, compress, OCR, sign and convert. Client-side via WebAssembly with no uploads required.
+- [PDFGem](https://pdfgem.io) - Browser-based PDF tools to merge, split, compress, OCR, sign and convert. Client-side via WebAssembly with no uploads required. 🪟 🍎 🐧
 
 ## Note Taking
 
@@ -508,7 +508,7 @@
 - [PhotoFiltre](https://photofiltre-studio.com/pf7-en.htm) - Complete image retouching program. 🪟
 - [Pencil2D](https://pencil2d.org) - Simple and intuitive tool for creating 2D hand-drawn animations. 🪟 🍎 🐧
 - [Pixen](https://pixenapp.com/mac) - Native pixel art and animation editor designed. 🍎
-- [Vizua](https://vizua.io) - Browser-based image tools to compress, resize, convert, remove backgrounds, upscale and OCR. All processing runs client-side.
+- [Vizua](https://vizua.io) - Browser-based image tools to compress, resize, convert, remove backgrounds, upscale and OCR. All processing runs client-side. 🪟 🍎 🐧
 
 ## 3D Modeling and Animation
 


### PR DESCRIPTION
Adds two free browser-based tool suites:

- **PDFGem** (https://pdfgem.io) — PDF tools (merge, split, compress, OCR, sign, convert). Added to **PDF Tools** section.
- **Vizua** (https://vizua.io) — Image tools (compress, resize, convert, remove background, upscale, OCR). Added to **Graphics Tools** section.

Both are fully client-side (WebAssembly) — files never leave the browser. No account required.