### PR TITLE
Add MDLook to Text Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@
 - [Vim](https://www.vim.org) - Efficient command-line editor with powerful keyboard shortcuts and multi-file editing. 🪟 🍎 🐧 [🟢](https://github.com/vim/vim)
 - [Vimr](http://vimr.org) - Editor offering a refined Vim experience with enhanced UI and modern features. 🍎 [🟢](https://github.com/qvacua/vimr)
 - [Zed](https://zed.dev) - High-performance, collaborative editor designed for speed, real-time collaboration, and custom workflows. 🍎 🐧 [🟢](https://github.com/zed-industries/zed)
+- [MDLook](https://mdlook.com) - Portable offline Markdown editor using WebView2 with live preview, dark mode, and diagram support. 🪟
 
 ## Download Managers
 


### PR DESCRIPTION
Add MDLook to the Text Editors section.

- Website: https://mdlook.com
- GitHub: https://github.com/djosci/MDLook

MDLook is a portable, fully offline Markdown editor for Windows. Uses WebView2 instead of Electron (~42 MB total, no installation required). Features split-pane editing with live preview, dark mode, KaTeX math, Mermaid diagrams, and syntax highlighting.