### PR TITLE
Add SammaPix — 27 free browser-based image tools (Graphics Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@
 - [Krita](https://krita.org) - Digital painting software designed for illustrators and concept artists. 🪟 🍎 🐧 🟢 ⭐
 - [Aspect](https://aspect.bildhuus.com) - Photo organizer with peer-to-peer synchronization for secure image storage. 🪟 🍎 🐧
 - [pngquant](https://pngquant.org) - Command-line tool for compressing PNG images without losing quality. 🪟 🍎 🐧
+- [SammaPix](https://www.sammapix.com) - 27 browser-based image tools: compress, resize, convert, remove background, passport photos, AI rename. Privacy-first — all processing runs client-side. 🌐
 - [Alchemy](https://al.chemy.org) - Experimental drawing application focused on conceptual art creation. 🪟 🍎 🐧
 - [Amadine](https://amadine.com) - Intuitive vector drawing app aimed at graphic designers. 🍎
 - [Colorpicker](https://colorpicker.fr) - Color manipulation tool for picking and modifying colors. 🪟 🍎 🐧 🟢


### PR DESCRIPTION
## SammaPix

[SammaPix](https://www.sammapix.com) — 27 free browser-based image tools.

**What it does:** compress, resize, convert (HEIC/WebP/AVIF/JXL), AI background removal, passport photos (140+ countries), AI rename, batch watermark, duplicate finder, EXIF removal, and more.

**Why it's free:** all processing runs client-side via Canvas API and WebAssembly. No server costs for image processing = genuinely free, no credit limits.

**Privacy:** images never leave the user's device. No signup required.

Added to **Graphics Tools** next to pngquant (similar category — image optimization).

🌐 Web-based (runs in any browser)