### PR TITLE
Add WobblePic to Image Viewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,7 @@
 - [Irfanview](https://irfanview.com) - Simple image viewer with some editing abilities. 🪟
 - [JPEGView](https://sourceforge.net/projects/jpegview) - Lean, fast and highly configurable viewer/editor for JPEG, BMP, PNG, WEBP, TGA, GIF and TIFF images. 🪟
 - [qView](https://interversehq.com/qview) - Visually minimal and space efficient. 🪟 🍎 🐧
+- [WobblePic](https://wobblepic.com) - Image viewer with soft-body physics and SAM2 segmentation; drag images and they jiggle. 🪟 🍎
 - [XnView](https://xnview.com/en) - Image resizer, batch image converter. 🪟 🍎 🐧
 
 ## Remote Access


### PR DESCRIPTION
### Adding
WobblePic — a free image viewer for Windows + macOS with a unique soft-body physics feature (drag images and they wobble like rubber). Also uses SAM2 for automatic object segmentation.

- Website: https://wobblepic.com
- Platforms: Windows 10/11, macOS (Apple Silicon + Intel)
- Closed-source freeware
- Actively maintained (v1.2.1)

Placed alphabetically between qView and XnView in the Image Viewers section.
