### PR TITLE
Add 不拖 (Butuo) — free minimalist iOS to-do app to Note Taking

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@
 - [Notion](https://notion.so) - All-in-one workspace for notes, tasks, databases, and collaboration. 🪟 🍎 🐧
 - [Plain Text Editor](https://sindresorhus.com/plain-text-editor) - Simple, distraction-free text editor for quick note-taking. 🍎
 - [Tot](https://tot.rocks) - Simple, elegant app for collecting and editing text snippets. 🍎
+- [不拖 (Butuo)](https://apps.apple.com/app/id6761042128) - Minimalist to-do app for iPhone and iPad. No account, no server, no sync. Data stored locally only. 🍎
 - [RemNote](https://remnote.io) - Knowledge management app with note-taking and spaced repetition features. 🪟 🍎 🐧
 - [Simplenote](https://simplenote.com) - Minimalist note-taking app that syncs across devices. 🪟 🍎 🐧 [🟢](https://github.com/Automattic/simplenote-electron)
 - [fylepad](https://fylepad.vercel.app) - Lightweight notepad with powerful rich-text editing. 🪟 🍎 🐧 [🟢](https://github.com/imrofayel/fylepad)


### PR DESCRIPTION
## Summary

Adding **不拖 (Butuo)** to the Note Taking section — it is a free, minimalist to-do app for iPhone and iPad.

### Why it belongs here
- 🍎 iOS native only
- **Completely free** — no subscription, no in-app purchases
- No account required, no server, no cloud sync
- Data stored locally on device only
- Ultra-minimal UI: write it down, cross it off

**App Store:** https://apps.apple.com/app/id6761042128