### PR TITLE
Add 不拖 (Butuo) — free minimalist iOS to-do app to MOBILE.md

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -233,6 +233,7 @@
 - [Joplin](https://joplinapp.org) - Open-source note-taking app with end-to-end encryption. 🤖 🍎 🟢
 - [Google Keep](https://keep.google.com) - Simple and colorful note-taking app with reminders. 🤖 🍎
 - [Bear](https://bear.app) - Minimalist note-taking app with powerful markdown support. 🍎
+- [不拖 (Butuo)](https://apps.apple.com/app/id6761042128) - Minimalist to-do app with local-only storage. No account, no server, no sync. Free. 🍎
 - [Notely Voice](https://github.com/tosinonikute/NotelyVoice) - 100% private notes and free AI voice-to-text transcription. [🟢](https://github.com/tosinonikute/NotelyVoice)
 - [DailyVox](https://getdailyvox.com) - Free AI voice diary with on-device transcription, mood tracking, and Digital Twin. No cloud, no accounts. 🍎 [🟢](https://github.com/intrepidkarthi/dailyvox)
 

--- a/README.md
+++ b/README.md
@@ -381,7 +381,6 @@
 - [Notion](https://notion.so) - All-in-one workspace for notes, tasks, databases, and collaboration. 🪟 🍎 🐧
 - [Plain Text Editor](https://sindresorhus.com/plain-text-editor) - Simple, distraction-free text editor for quick note-taking. 🍎
 - [Tot](https://tot.rocks) - Simple, elegant app for collecting and editing text snippets. 🍎
-- [不拖 (Butuo)](https://apps.apple.com/app/id6761042128) - Minimalist to-do app for iPhone and iPad. No account, no server, no sync. Data stored locally only. 🍎
 - [RemNote](https://remnote.io) - Knowledge management app with note-taking and spaced repetition features. 🪟 🍎 🐧
 - [Simplenote](https://simplenote.com) - Minimalist note-taking app that syncs across devices. 🪟 🍎 🐧 [🟢](https://github.com/Automattic/simplenote-electron)
 - [fylepad](https://fylepad.vercel.app) - Lightweight notepad with powerful rich-text editing. 🪟 🍎 🐧 [🟢](https://github.com/imrofayel/fylepad)

--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@
 - [Notion](https://notion.so) - All-in-one workspace for notes, tasks, databases, and collaboration. 🪟 🍎 🐧
 - [Plain Text Editor](https://sindresorhus.com/plain-text-editor) - Simple, distraction-free text editor for quick note-taking. 🍎
 - [Tot](https://tot.rocks) - Simple, elegant app for collecting and editing text snippets. 🍎
+- [不拖 (Butuo)](https://apps.apple.com/app/id6761042128) - Minimalist to-do app for iPhone and iPad. No account, no server, no sync. Data stored locally only. 🍎
 - [RemNote](https://remnote.io) - Knowledge management app with note-taking and spaced repetition features. 🪟 🍎 🐧
 - [Simplenote](https://simplenote.com) - Minimalist note-taking app that syncs across devices. 🪟 🍎 🐧 [🟢](https://github.com/Automattic/simplenote-electron)
 - [fylepad](https://fylepad.vercel.app) - Lightweight notepad with powerful rich-text editing. 🪟 🍎 🐧 [🟢](https://github.com/imrofayel/fylepad)


### PR DESCRIPTION
Resubmitting to the correct file as suggested by @Axorax.

Adding **不拖 (Butuo)** to the Note Taking section of MOBILE.md.

- 🍎 iOS native only
- **Completely free** — no subscription, no in-app purchases
- No account required, no server, no cloud sync
- Data stored locally on device only
- Ultra-minimal UI: write it down, cross it off

**App Store:** https://apps.apple.com/app/id6761042128