### PR TITLE
Add: niri

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,6 +715,7 @@
 - [XMonad](https://xmonad.org) - Customizable tiling window manager. 🐧
 - [YASB](https://github.com/amnweb/yasb) - Highly configurable Windows status bar. 🪟 🟢
 - [Komorebi](https://github.com/LGUG2Z/komorebi) - Tiling window manager for Windows. 🪟 🟢
+- [Niri](https://github.com/niri-wm/niri) - Scrollable-tiling Wayland compositor written in Rust. 🐧 🟢
 
 ### File Management
 


### PR DESCRIPTION
Niri is a new trending Wayland compositor with scrollable tiling. I think it deserves to be here.

'written in Rust' can be removed, if it suits the style of this repo more.

Also don't judge me for having 0 star account please.