### PR TITLE
Add qnote to Note Taking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@
 - [Tot](https://tot.rocks) - Simple, elegant app for collecting and editing text snippets. 🍎
 - [RemNote](https://remnote.io) - Knowledge management app with note-taking and spaced repetition features. 🪟 🍎 🐧
 - [Simplenote](https://simplenote.com) - Minimalist note-taking app that syncs across devices. 🪟 🍎 🐧 [🟢](https://github.com/Automattic/simplenote-electron)
+- [qnote](https://github.com/Omibranch/qnote) - Minimal frameless notepad with Markdown preview, real PDF export via Typst, OCR via Tesseract, and automatic version history. 🐧 [🟢](https://github.com/Omibranch/qnote)
 - [fylepad](https://fylepad.vercel.app) - Lightweight notepad with powerful rich-text editing. 🪟 🍎 🐧 [🟢](https://github.com/imrofayel/fylepad)
 
 ## Text Editors


### PR DESCRIPTION
**qnote** is a minimal frameless notepad for Linux built with Tauri 2 (Rust + TypeScript).

Key features:
- Markdown preview with live split view
- Real PDF export via Typst (not HTML-to-PDF)
- OCR via Tesseract (supports eng+rus)
- Automatic version history with configurable intervals
- Dark/light themes, custom fonts
- Available on AUR

GitHub: https://github.com/Omibranch/qnote
License: MIT