### PR TITLE
Add: BeeCount

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -244,6 +244,10 @@
 - [Textastic](https://textasticapp.com) - Code and text editor with syntax support for numerous languages. 🍎
 - [AIDE](https://play.google.com/store/apps/details?id=com.aide.ui) - Mobile IDE to code and build Android apps on the go. 🤖
 
+## Finance
+
+- [BeeCount](https://github.com/TNT-Likely/BeeCount) - Privacy-first cross-platform expense tracker with self-hostable cloud sync (BeeCount Cloud, iCloud, Supabase, WebDAV, S3) and offline-first design. 🤖 🍎
+
 ## Download Managers
 
 - [IDM](https://play.google.com/store/apps/details?id=com.downloadmanager.app&hl=en) - Accelerates downloads with advanced scheduling and queuing. 🤖

--- a/MOBILE.md
+++ b/MOBILE.md
@@ -246,7 +246,7 @@
 
 ## Finance
 
-- [BeeCount](https://github.com/TNT-Likely/BeeCount) - Privacy-first cross-platform expense tracker with self-hostable cloud sync (BeeCount Cloud, iCloud, Supabase, WebDAV, S3) and offline-first design. 🤖 🍎
+- [BeeCount](https://github.com/TNT-Likely/BeeCount/blob/main/README_EN.md) - Privacy-first cross-platform expense tracker with self-hostable cloud sync (BeeCount Cloud, iCloud, Supabase, WebDAV, S3) and offline-first design. 🤖 🍎
 
 ## Download Managers
 


### PR DESCRIPTION
## Summary

Adds **BeeCount** to MOBILE.md under a new `## Finance` category.

BeeCount is a privacy-first cross-platform expense tracker (Android & iOS), offline-first, with multi-cloud sync — self-hostable BeeCount Cloud, iCloud, Supabase, WebDAV, S3. Free for personal use, no ads, no subscription.

- Source: https://github.com/TNT-Likely/BeeCount (~1.5k★, active)
- App Store: https://apps.apple.com/app/id6754611670
- Google Play: https://play.google.com/store/apps/details?id=com.tntlikely.beecount

## Compliance with CONTRIBUTING.md

- [x] Editing only `MOBILE.md` (mobile app)
- [x] Did not change order of existing apps
- [x] Did not modify TOC or `filter` folder
- [x] Description is concise, mentions features, ends with period
- [x] Added a new `## Finance` category (placed alphabetically between `E-book` related apps and `Download Managers`)
- [x] Commit message: `Add: BeeCount`
- [x] Both Android (🤖) and iOS (🍎) icons included

## Affiliation disclosure

I am the author of BeeCount (@TNT-Likely).