### PR TITLE
Add PureSnitch (Firewall)

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,10 @@
 
 - [SaneHosts](https://sanehosts.com) - macOS hosts file manager for system-wide ad and tracker blocking. 🍎 [🟢](https://github.com/sane-apps/SaneHosts)
 
+### Firewall
+
+- [PureSnitch](https://github.com/momenbasel/puresnitch) - Open-source application firewall for macOS. Little Snitch-style world map, rules manager, DNS over HTTPS, pf-based blocking, no telemetry. 🍎 [🟢](https://github.com/momenbasel/puresnitch)
+
 ## Image Viewers
 
 - [ImageGlass](https://imageglass.org) - Lightweight, versatile image viewer. 🪟 🟢 ⭐


### PR DESCRIPTION
Adds PureSnitch under a new **Firewall** subsection within Security.

PureSnitch is a free, open-source application firewall for macOS. Little Snitch-style world map, rules manager, DNS over HTTPS, pf-based IP/CIDR/port blocking, no telemetry. MIT licensed, signed and notarized by Apple.

Created a new Firewall subsection since the Security section had no firewall entries. Happy to fold it into an existing subsection if you prefer.

- Repo: https://github.com/momenbasel/puresnitch
- License: MIT