### PR TITLE
add: plumio to notes-taking apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@
 - [Simplenote](https://simplenote.com) - Minimalist note-taking app that syncs across devices. 🪟 🍎 🐧 [🟢](https://github.com/Automattic/simplenote-electron)
 - [qnote](https://github.com/Omibranch/qnote) - Minimal frameless notepad with Markdown preview, real PDF export via Typst, OCR via Tesseract, and automatic version history. 🐧 [🟢](https://github.com/Omibranch/qnote)
 - [fylepad](https://fylepad.vercel.app) - Lightweight notepad with powerful rich-text editing. 🪟 🍎 🐧 [🟢](https://github.com/imrofayel/fylepad)
+- [plumio](https://plumio.app) - Privacy-first, open-source, self-hostable notes-taking app. 🪟 🍎 🐧 [🟢](https://github.com/albertasaftei/plumio)
 
 ## Text Editors
 


### PR DESCRIPTION
plumio is an open-source, self-hosted note-taking app.

I want to specify that the windows, macos, linux installable versions are not signed with a developer certificate. They are generated on every release, i wanted to add them just to give some users another option of installation. Thus tell me if this is the correct place to add it and if we can keep the emojis or not :)

[Website](https://plumio.app/)
[Demo](https://demo.plumio.app/)
[Github repo](https://github.com/albertasaftei/plumio)

