### PR TITLE
Add: Universal Installer

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -368,6 +368,7 @@
 
 - [AppMgr III](https://play.google.com/store/apps/details?id=com.a0soft.gphone.app2sd) - Move apps to external storage and manage installed apps. 🤖
 - [Titanium Backup](https://play.google.com/store/apps/details?id=com.keramidas.TitaniumBackup) - Advanced app backup and restore tool (root required). 🤖
+- [Universal Installer](https://github.com/pass-with-high-score/universal-installer) - Install split APKs, XAPK, APKM, and APKS bundles with Shizuku silent installs and VirusTotal scans. 🤖 🟢
 
 ### Screenshot
 


### PR DESCRIPTION
Adds Universal Installer (Android) to MOBILE.md under Application Management, per #147.

- Repo: https://github.com/pass-with-high-score/universal-installer (GPLv3, 282 stars)
- Description: split APK / XAPK / APKM / APKS support, silent installs via Shizuku, VirusTotal scanning.

Per contributing.md the new entry is appended at the bottom of the Application Management subsection and uses 🤖 (Android) + 🟢 (open-source) markers.

Closes #147