### PR TITLE
fix(mobile): remove Kiwi Browser and add maintained alternatives

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -120,7 +120,8 @@
 - [Brave](https://brave.com) - Ad-blocking browser with built-in privacy tools and rewards system. 🤖 🍎
 - [DuckDuckGo Privacy Browser](https://duckduckgo.com/app) - Focuses on privacy with no tracking and private search. 🤖 🍎
 - [Opera](https://www.opera.com/mobile) - Built-in ad blocker, VPN, and offline file sharing. 🤖 🍎
-- [Kiwi Browser](https://kiwibrowser.com) - Lightweight browser supporting Chrome extensions on mobile. 🤖
+- [Cromite](https://www.cromite.org) - Privacy-focused Chromium fork with ad-blocking and anti-tracking defaults. 🤖
+- [Microsoft Edge](https://www.microsoft.com/edge/mobile) - Cross-platform browser with sync, privacy controls, and AI-assisted tools. 🤖 🍎
 
 ## Communication
 

--- a/filter/android-only.md
+++ b/filter/android-only.md
@@ -118,7 +118,8 @@
 - [Brave](https://brave.com) - Ad-blocking browser with built-in privacy tools and rewards system. 🤖 🍎
 - [DuckDuckGo Privacy Browser](https://duckduckgo.com/app) - Focuses on privacy with no tracking and private search. 🤖 🍎
 - [Opera](https://www.opera.com/mobile) - Built-in ad blocker, VPN, and offline file sharing. 🤖 🍎
-- [Kiwi Browser](https://kiwibrowser.com) - Lightweight browser supporting Chrome extensions on mobile. 🤖
+- [Cromite](https://www.cromite.org) - Privacy-focused Chromium fork with ad-blocking and anti-tracking defaults. 🤖
+- [Microsoft Edge](https://www.microsoft.com/edge/mobile) - Cross-platform browser with sync, privacy controls, and AI-assisted tools. 🤖 🍎
 
 ## Communication
 


### PR DESCRIPTION
## Summary
This PR addresses issue #134 by removing Kiwi Browser from the mobile browser lists and replacing it with currently maintained alternatives.

## Changes
- Removed Kiwi Browser from MOBILE.md browser section
- Removed Kiwi Browser from filter/android-only.md browser section
- Added Cromite as an Android browser alternative
- Added Microsoft Edge as an actively maintained cross-platform browser option

## Why
Issue #134 reports Kiwi Browser as effectively unmaintained and requests removal from the curated list. This keeps recommendations current and reliable.

Closes #134