### PR TITLE
feat: Add "Move to top" links for section navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@
 - [Ambie](https://github.com/jenius-apps/ambie) - Use white noise, nature sounds, & more to boost your productivity. 🪟 🟢
 - [BlackHole](https://github.com/ExistentialAudio/BlackHole) - Virtual audio loopback driver for routing audio between macOS applications. 🍎 🟢
 
+[Move to top](#contents)
+
 ### Audio Players
 
 - [Foobar2000](https://foobar2000.org) - Lightweight and highly customizable audio player with support for many formats. 🪟 🍎 ⭐
@@ -99,11 +101,15 @@
 - [MusicBee](https://getmusicbee.com) - Feature-rich music player and manager. 🪟
 - [Strawberry Music Player](https://strawberrymusicplayer.org) - Music player for organizing and playing your audio collection. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ### Audio Recording
 
 - [Audacity](https://audacityteam.org/download) - Audio editor for recording and editing sounds. 🪟 🍎 🐧 🟢 ⭐
 - [Ocenaudio](https://ocenaudio.com) - Easy-to-use audio editor for recording and analyzing sounds. 🪟 🍎 🐧
 - [Wavosaur](https://www.wavosaur.com) - Simple audio editor for recording, editing, and processing sound. 🪟
+
+[Move to top](#contents)
 
 ### DJ Software
 
@@ -113,6 +119,8 @@
 - [Rekordbox](https://rekordbox.com/en) - Software that enables a comfortable DJ workflow with AI, cloud, and automation tech. 🪟 🍎
 - [VirtualDJ](https://virtualdj.com) - DJ platform for mixing music, beatmatching, and live performance. 🪟 🍎
 
+[Move to top](#contents)
+
 ### Music Notation
 
 - [ABCjs](https://abcjs.net) - Tool for writing and playing ABC music notation. 🪟 🍎 🐧
@@ -120,6 +128,8 @@
 - [Frescobaldi](https://frescobaldi.org) - Editor for LilyPond to create music scores quickly. 🪟 🍎 🐧
 - [LilyPond](https://lilypond.org) - Music notation program for creating high-quality sheet music. 🪟 🍎 🐧
 - [MuseScore](https://musescore.org) - Software for creating, playing, and sharing sheet music. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ### Music Production
 
@@ -132,6 +142,8 @@
 - [Qtractor](https://qtractor.org) - Multi-track DAW for Linux for audio and MIDI recording. 🐧
 - [Stargate DAW](https://github.com/stargatedaw/stargate) - Innovation-first DAW, instrument and effect plugins. 🪟 🍎 🐧 🟢
 - [Tracktion T7](https://tracktion.com/products/t7-daw) - DAW for music production with advanced editing features. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ## Browsers
 
@@ -155,7 +167,11 @@
 - [Vivaldi](https://vivaldi.com) - Customizable browser putting you in control. 🪟 🍎 🐧
 - [Zen Browser](https://zen-browser.app) - Beautifully designed, privacy-focused browser with custom mods. 🪟 🍎 🐧 [🟢](https://github.com/zen-browser/desktop)
 
+[Move to top](#contents)
+
 ## Communication
+
+[Move to top](#contents)
 
 ### Messaging
 
@@ -167,6 +183,8 @@
 - [Viber](https://viber.com) - Free messaging app with text, voice, video calls, and file sharing. 🪟 🍎 🐧
 - [Microsoft Teams](https://microsoft.com/en-us/microsoft-teams/group-chat-software) - Team communication platform with chat, file sharing, and video conferencing. 🪟 🍎 🐧
 - [Skype](https://skype.com) - Messaging and video call service supporting text, voice, and video. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ### Email Clients
 
@@ -187,6 +205,8 @@
 - [ThunderBird](https://thunderbird.net) - Email client for easier management. 🪟 🍎 🐧 🟢
 - [Tutanota](https://tutanota.com) - Encrypted service focused on privacy. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ## Compression and Archiving
 
 - [7-Zip](https://7-zip.org/download.html) - Archive manager supporting 7z, ZIP, and other formats. 🪟 🟢 ⭐
@@ -199,7 +219,11 @@
 - [Unarchive One](https://cleanerone.trendmicro.com/unarchiver-one/?utm_source=github&utm_medium=referral&utm_campaign=githubproject) - Multi-format decompression tool with QuickLook integration. 🍎
 - [Keka](https://www.keka.io) - File archiver for compressing and extracting common archive formats. 🍎
 
+[Move to top](#contents)
+
 ## Customize
+
+[Move to top](#contents)
 
 ### System Customization
 
@@ -221,6 +245,8 @@
 - [SaneClick](https://saneclick.com) - Finder toolbar customizer for adding quick actions. 🍎 [🟢](https://github.com/sane-apps/SaneClick)
 - [Thaw](https://github.com/stonerl/Thaw) - Menu bar manager for hiding, arranging, and customizing menu bar items. 🍎 [🟢](https://github.com/stonerl/Thaw)
 
+[Move to top](#contents)
+
 ### Wallpaper Tools
 
 - [Lively Wallpaper](https://rocksdanister.com/lively) - Tool to set animated and interactive wallpapers. 🪟 🟢 ⭐
@@ -232,7 +258,11 @@
 - [WinDynamicDesktop](https://github.com/t1m0thyj/WinDynamicDesktop) - Port of macOS Mojave Dynamic Desktop feature to Windows. 🪟 🟢
 - [Sucrose](https://github.com/Taiizor/Sucrose) - Versatile wallpaper engine bringing life to your desktop with a wide range of interactive themes. 🪟 🟢
 
+[Move to top](#contents)
+
 ## Data Management
+
+[Move to top](#contents)
 
 ### Copy and Move
 
@@ -240,11 +270,15 @@
 - [TeraCopy](https://codesector.com/teracopy) - Copy and move multiple files. 🪟 🍎
 - [Blip](https://blip.net) - Direct file transfer app with unlimited file sizes, folder support, and transfer resume. 🪟 🍎 ⭐
 
+[Move to top](#contents)
+
 ### Sync and Clone
 
 - [FreeFileSync](https://freefilesync.org) - Tool for comparing and syncing files or folders. 🪟 🍎 🐧 🟢 ⭐
 - [rclone](https://rclone.org) - Command-line tool for managing and syncing files with cloud storage. 🪟 🍎 🐧
 - [Syncthing](https://github.com/syncthing/syncthing) - Continuous file synchronization for multiple computers. 🪟 🍎 🐧 🟢
+
+[Move to top](#contents)
 
 ## Developer Tools
 
@@ -261,6 +295,8 @@
 - [Android Studio](https://developer.android.com/studio) - Official IDE for Android development with emulator, code editor, and build tools. 🪟 🍎 🐧
 - [GitHub Desktop](https://desktop.github.com) - Graphical Git client for cloning repositories, reviewing changes, and syncing with GitHub. 🪟 🍎 [🟢](https://github.com/desktop/desktop)
 - [WezTerm](https://wezterm.org) - GPU-accelerated terminal emulator and multiplexer with tabs, panes, SSH, and Lua configuration. 🪟 🍎 🐧 [🟢](https://github.com/wezterm/wezterm)
+
+[Move to top](#contents)
 
 ### API Development
 
@@ -279,12 +315,16 @@
 - [Yaak](https://yaak.app) - An offline and Git friendly API tester for HTTP, GraphQL, WebSockets, SSE, and gRPC. 🪟 🍎 🐧 [🟢](https://github.com/mountain-loop/yaak)
 - [Endpoint](https://apps.apple.com/tr/app/endpoint-http-client/id6755891816?mt=12) - Native macOS API client with WebSocket support, performance testing, and customizable themes. 🍎
 
+[Move to top](#contents)
+
 ### Database
 
 - [DBeaver](https://dbeaver.io) - Universal database tool for SQL databases like MySQL, MariaDB, PostgreSQL, SQLite, Apache Family, and more. 🪟 🍎 🐧 ⭐
 - [Beekeeper Studio](https://beekeeperstudio.io) - Modern, lightweight SQL client supporting MySQL, Postgres, SQLite, SQL Server, etc. 🪟 🍎 🐧
 - [DB Browser for SQLite](https://sqlitebrowser.org) - Visual tool for creating, browsing, and editing SQLite database files. 🪟 🍎 🐧 [🟢](https://github.com/sqlitebrowser/sqlitebrowser)
 - [DearSQL](https://dearsql.dev) - Lightweight native database client built with Dear ImGui, supporting SQL and NoSQL databases. 🪟 🍎 🐧 [🟢](https://github.com/dunkbing/dearsql)
+
+[Move to top](#contents)
 
 ### Network Analysis
 
@@ -296,6 +336,8 @@
 - [Proxie](https://proxie.app) - HTTP debugging proxy for tracking requests. 🍎
 - [Proxyman](https://proxyman.io) - Modern HTTP proxy with an intuitive UI. 🍎
 - [Sniffnet](https://sniffnet.net) - Tool for monitoring and analyzing network traffic. 🪟 🍎 🐧 [🟢](https://github.com/GyulyVGC/sniffnet)
+
+[Move to top](#contents)
 
 ### Game Engines
 
@@ -321,6 +363,8 @@
 - [Tiled](https://mapeditor.org) - Level editor for creating tile-based game maps, used with other engines. 🪟 🍎 🐧 🟢
 - [Unity](https://unity.com) - Popular game engine for creating both 2D and 3D games, with an intuitive interface and wide asset store. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ### Virtualization
 
 - [Docker](https://docker.com) - Containerization platform for operating-system-level virtualization. 🪟 🍎 🐧 🟢 ⭐
@@ -337,9 +381,13 @@
 - [eryph-zero](https://eryph.io) - Tool for building VMs as if they were running in the cloud, but locally on Windows. 🪟 🟢
 - [Mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS built on Apple's Containerization framework. 🍎 [🟢](https://github.com/us/mocker)
 
+[Move to top](#contents)
+
 ## Documents
 
 - [CDisplayEx](https://www.cdisplayex.com) - Lightweight comic book reader (.cbr, .cbz, .pdf, manga). 🪟
+
+[Move to top](#contents)
 
 ### Office Suites
 
@@ -353,6 +401,8 @@
 - [OnlyOffice](https://onlyoffice.com) - Office suite with collaboration features. 🪟 🍎 🐧 🟢
 - [WPS Office](https://wps.com) - Lightweight office suite compatible with MS file formats. 🪟 🍎 🐧
 
+
+[Move to top](#contents)
 
 ### E-book
 
@@ -368,6 +418,8 @@
 - [Sigil](https://sigil-ebook.com) - EPUB editor. 🪟 🍎 🐧 [🟢](https://github.com/Sigil-Ebook/Sigil)
 - [Simple Comic](https://apps.apple.com/us/app/simple-comic/id1497435571?mt=12) - Reader for PDF, CBZ, and CBR formats. 🍎
 
+[Move to top](#contents)
+
 ### PDF Tools
 
 - [Sumatra PDF](https://sumatrapdfreader.org/free-pdf-reader) - Fast, lightweight PDF reader. 🪟 [🟢](https://github.com/sumatrapdfreader/sumatrapdf) ⭐
@@ -381,6 +433,8 @@
 - [Xournal++](https://xournalpp.github.io) - Handwriting and annotation tool for PDFs. 🪟 🍎 🐧 [🟢](https://github.com/xournalpp/xournalpp)
 - [PDFGear](https://www.pdfgear.com) - Read, edit, convert, merge, and sign PDF files across devices. 🪟 🍎
 - [PDFsam](https://pdfsam.org) - Extract pages, split, merge, mix and rotate PDF files. 🪟 🍎 🐧 [🟢](https://github.com/torakiki/pdfsam)
+
+[Move to top](#contents)
 
 ## Note Taking
 
@@ -397,6 +451,8 @@
 - [qnote](https://github.com/Omibranch/qnote) - Minimal frameless notepad with Markdown preview, real PDF export via Typst, OCR via Tesseract, and automatic version history. 🐧 [🟢](https://github.com/Omibranch/qnote)
 - [fylepad](https://fylepad.vercel.app) - Lightweight notepad with powerful rich-text editing. 🪟 🍎 🐧 [🟢](https://github.com/imrofayel/fylepad)
 - [plumio](https://plumio.app) - Privacy-first, open-source, self-hostable notes-taking app. 🪟 🍎 🐧 [🟢](https://github.com/albertasaftei/plumio)
+
+[Move to top](#contents)
 
 ## Text Editors
 
@@ -430,6 +486,8 @@
 - [VSCodium](https://vscodium.com) - Community-built VS Code binaries without Microsoft branding, telemetry, or licensing changes. 🪟 🍎 🐧 [🟢](https://github.com/VSCodium/vscodium)
 - [MarkEdit](https://github.com/MarkEdit-app/MarkEdit) - Native Markdown editor for macOS with a TextEdit-like workflow and local-file editing. 🍎 🟢
 
+[Move to top](#contents)
+
 ## Download Managers
 
 - [AB Download Manager](https://abdownloadmanager.com) - Easily download files from anywhere. 🪟 🐧 [🟢](https://github.com/amir1376/ab-download-manager) ⭐
@@ -441,6 +499,8 @@
 - [Persepolis Download Manager](https://persepolisdm.github.io) - GUI for Aria2, providing an intuitive interface. 🪟 🍎 🐧 [🟢](https://github.com/persepolisdm/persepolis)
 - [Xtreme Download Manager (XDM)](https://xtremedownloadmanager.com) - Powerful tool to increase download speed. 🪟 🍎 🐧 [🟢](https://github.com/subhra74/xdm)
 - [Transmission](https://transmissionbt.com) - Lightweight BitTorrent client with native desktop, daemon, and web interfaces. 🪟 🍎 🐧 [🟢](https://github.com/transmission/transmission)
+
+[Move to top](#contents)
 
 ## Games
 
@@ -463,12 +523,16 @@
 - [Porting Kit](https://portingkit.com) - Install Windows games on Mac. 🍎
 - [Ubisoft Connect](https://ubisoftconnect.com) - Game launcher for Ubisoft titles. 🪟 🍎
 
+[Move to top](#contents)
+
 ### Cloud Gaming
 
 - [Antstream Arcade](https://www.antstream.com) - Free tier with retro games playable via the cloud. 🪟 🍎 🐧
 - [Boosteroid](https://boosteroid.com) - Free plan available for limited game streaming. 🪟 🍎 🐧
 - [NVIDIA GeForce NOW](https://www.nvidia.com/en-us/geforce-now) - Free tier for streaming supported games from the cloud. 🪟 🍎 🐧
 - [Xbox Cloud Gaming](https://www.xbox.com/en-US/play) - Free trial with limited titles via the cloud. 🪟 🍎
+
+[Move to top](#contents)
 
 ## Mobile Emulators
 
@@ -480,6 +544,8 @@
 - [MEmu Play](https://memuplay.com) - Powerful Android emulator with excellent gaming support. 🪟
 - [NoxPlayer](https://bignox.com) - Android emulator optimized for mobile gaming on desktop. 🪟 🍎
 - [Waydroid](https://waydro.id) - Container-based approach to boot a full Android system. 🐧 [🟢](https://github.com/waydroid/waydroid)
+
+[Move to top](#contents)
 
 ## Other Emulators
 
@@ -500,6 +566,8 @@
 - [Mednafen](https://mednafen.github.io) - Multi-system emulator with a focus on precision and compatibility. 🪟 🐧
 - [MelonDS](https://melonds.kuribo64.net) - Nintendo DS emulator with accurate performance and Wi-Fi support. 🪟 🍎 🐧
 - [BSNES](https://bsnes.dev) - SNES emulator with cycle-accurate emulation for high compatibility. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ## Graphics Tools
 
@@ -526,6 +594,8 @@
 - [Pixen](https://pixenapp.com/mac) - Native pixel art and animation editor designed. 🍎
 - [Affinity](https://www.affinity.studio/) - Professional creative suite for photo editing, graphic design, and desktop publishing. 🪟 🍎
 
+[Move to top](#contents)
+
 ## 3D Modeling and Animation
 
 - [Blender](https://blender.org) - 3D creation tool supporting modeling, animation, rendering, video editing, and more. 🪟 🍎 🐧 🟢 ⭐
@@ -534,7 +604,11 @@
 - [OpenSCAD](https://openscad.org) - Script-based 3D CAD modeler for creating precise solid geometry. 🪟 🍎 🐧
 - [Wings 3D](https://www.wings3d.com) - 3D modeling software focusing on subdivision modeling. 🪟 🍎 🐧 🟢
 
+[Move to top](#contents)
+
 ## Security
+
+[Move to top](#contents)
 
 ### Antivirus
 
@@ -544,6 +618,8 @@
 - [ClamAV](https://www.clamav.net) - Antivirus engine for detecting malware, viruses, and other threats. 🪟 🍎 🐧 🟢
 - [Malwarebytes](https://malwarebytes.com) - Malware removal tool offering real-time protection and cleanup. 🪟 🍎
 - [Pareto Security](https://paretosecurity.com/apps) - Check for basic security hygiene of any Windows, Mac or Linux desktop. 🪟 🍎 🐧 [🟢](https://github.com/paretoSecurity/agent)
+
+[Move to top](#contents)
 
 ### Password Managers
 
@@ -556,9 +632,13 @@
 - [RoboForm](https://roboform.com) - Password manager and form filler with multi-platform synchronization. 🪟 🍎 🐧
 - [ProtonPass](https://proton.me/pass) - Free password manager with end-to-end encryption based in Switzerland. 🪟 🍎 🐧 [🟢](https://github.com/protonpass)
 
+[Move to top](#contents)
+
 ### Ad & Tracker Blocking
 
 - [SaneHosts](https://sanehosts.com) - macOS hosts file manager for system-wide ad and tracker blocking. 🍎 [🟢](https://github.com/sane-apps/SaneHosts)
+
+[Move to top](#contents)
 
 ## Image Viewers
 
@@ -568,6 +648,8 @@
 - [JPEGView](https://sourceforge.net/projects/jpegview) - Lean, fast and highly configurable viewer/editor for JPEG, BMP, PNG, WEBP, TGA, GIF and TIFF images. 🪟
 - [qView](https://interversehq.com/qview) - Visually minimal and space efficient. 🪟 🍎 🐧
 - [XnView](https://xnview.com/en) - Image resizer, batch image converter. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ## Remote Access
 
@@ -584,9 +666,13 @@
 - [Remmina](https://remmina.org) - Remote access screen and file sharing to your desktop. 🐧
 - [RemSupp](https://remsupp.com) - Simple remote desktop. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ## Video
 
 - [FreeTube](https://freetubeapp.io) - Private YouTube client with no ads. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ### Video Editors
 
@@ -600,6 +686,8 @@
 - [Olive Video Editor](https://olivevideoeditor.org) - Non-linear video editor with powerful features and an intuitive interface. 🪟 🍎 🐧 [🟢](https://github.com/olive-editor/olive)
 - [Avidemux](https://avidemux.sourceforge.net) - Video editor designed for simple cutting, filtering and encoding tasks. 🪟 🍎 🐧 [🟢](https://github.com/mean00/avidemux2)
 - [lossless-cut](https://losslesscut.app) - Swiss army knife of lossless video/audio editing. 🪟 🍎 🐧 [🟢](https://github.com/mifi/lossless-cut)
+
+[Move to top](#contents)
 
 ### Video Players
 
@@ -619,6 +707,8 @@
 - [Videotape](https://usuaia.com/videotape) - Simple and minimalist video player for quick playback of local video files. 🪟
 - [VLC Media Player](https://videolan.org/vlc) - Media player supporting almost all video formats. 🪟 🍎 🐧 🟢
 
+[Move to top](#contents)
+
 ### Video Streaming and Recording
 
 - [OBS Studio](https://obsproject.com) - Software for live streaming and recording video. 🪟 🍎 🐧 🟢 ⭐
@@ -633,6 +723,8 @@
 - [Shadowplay](https://www.nvidia.com/en-ph/geforce/geforce-experience/shadowplay) - Record gameplay videos, screenshots, and livestreams. 🪟
 - [ScreenToGif](https://www.screentogif.com) - Record, edit, and create animated GIFs from your screen. 🪟 [🟢](https://github.com/NickeManarin/ScreenToGif)
 
+[Move to top](#contents)
+
 ### Video Converters and Compressors
 
 - [FFmpeg](https://ffmpeg.org) - Powerful tool for format conversion and multimedia editing. 🪟 🍎 🐧 🟢 ⭐
@@ -644,6 +736,8 @@
 - [XMedia Recode](https://xmedia-recode.de/en) - Multi-format converter with advanced video editing features. 🪟
 - [VidCoder](https://vidcoder.net) - User-friendly HandBrake-based transcoder with batch processing. 🪟 🍎 🟢
 - [Adapter](https://macroplant.com/adapter/video-converter) - Media converter app for video, audio, and images on Mac and Windows. 🪟 🍎
+
+[Move to top](#contents)
 
 ## VPN and Proxy Tools
 
@@ -666,6 +760,8 @@
 - [v2rayN](https://github.com/2dust/v2rayN) - Open source GUI for Xray and Sing-box. 🪟 🍎 🐧 🟢
 - [WireGuard](https://wireguard.com) - Fast, secure VPN protocol designed for simplicity. 🪟 🍎 🐧 [🟢](https://www.wireguard.com/repositories)
 - [Tailscale](https://tailscale.com) - Mesh VPN client for secure private networks using WireGuard. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ## Utility
 
@@ -699,6 +795,8 @@
 - [MonitorControl](https://monitorcontrol.app) - Controls external display brightness, volume, and contrast from macOS keyboard shortcuts and menu bar. 🍎 [🟢](https://github.com/MonitorControl/MonitorControl)
 - [balenaEtcher](https://etcher.balena.io) - Tool for safely flashing OS images to SD cards and USB drives. 🪟 🍎 🐧 [🟢](https://github.com/balena-io/etcher)
 
+[Move to top](#contents)
+
 ### Clipboard Management
 
 - [Beetroot](https://max.nardit.com/beetroot) - Clipboard manager with AI text transforms and OCR extraction. 🪟
@@ -714,6 +812,8 @@
 - [Qopy](https://github.com/0pandadev/qopy) - Minimalist clipboard manager with unique features. 🪟 🍎 🐧 🟢
 - [SaneClip](https://saneclip.com) - Clipboard manager that keeps all history local with search and formatting tools. 🍎 [🟢](https://github.com/sane-apps/SaneClip)
 
+[Move to top](#contents)
+
 ### Metadata
 
 - [ExifTool](https://exiftool.org) - Command-line tool for editing metadata in various file types. 🪟 🍎 🐧 ⭐
@@ -721,6 +821,8 @@
 - [MP3Tag](https://mp3tag.de/en) - Edit and manage metadata for audio files. 🪟
 - [PhotoME](https://photome.de) - View and edit EXIF metadata for photos. 🪟
 
+
+[Move to top](#contents)
 
 ### Window Management
 
@@ -741,6 +843,8 @@
 - [Niri](https://github.com/niri-wm/niri) - Scrollable-tiling Wayland compositor written in Rust. 🐧 🟢
 - [AltTab](https://alt-tab.app) - Window switcher that brings Windows-style alt-tab previews and controls to macOS. 🍎 [🟢](https://github.com/lwouis/alt-tab-macos)
 
+[Move to top](#contents)
+
 ### File Management
 
 - [Everything](https://voidtools.com) - Fast file search tool indexing the entire file system. 🪟 ⭐
@@ -756,11 +860,15 @@
 - [Sigma File Manager](https://github.com/aleksey-hoffman/sigma-file-manager) - Modern file manager with advanced features. 🪟 🐧 [🟢](https://github.com/aleksey-hoffman/sigma-file-manager)
 - [Cyberduck](https://cyberduck.io) - File transfer client for FTP, SFTP, WebDAV, S3, Azure, OneDrive, and other storage services. 🪟 🍎 [🟢](https://github.com/iterate-ch/cyberduck)
 
+[Move to top](#contents)
+
 ### Application Management
 
 - [Bulk Crap Uninstaller](https://www.bcuninstaller.com) - Powerful tool for uninstalling multiple applications and cleaning leftovers. 🪟 🟢 ⭐
 - [Revo Uninstaller](https://www.revouninstaller.com/revo-uninstaller-free-download) - Advanced uninstaller to remove programs and residual files with free tier. 🪟
 - [PureMac](https://github.com/momenbasel/PureMac) - macOS app manager and system cleaner for uninstalling apps, removing orphaned files, and cleaning caches. 🍎 🟢
+
+[Move to top](#contents)
 
 ### Screenshot
 
@@ -774,6 +882,8 @@
 - [Shutter](https://launchpad.net/shutter) - Feature-rich screenshot tool for Linux with an integrated editor for quick annotations. 🐧
 - [Snipaste](https://snipaste.com) - Free, Customizable, Portable snipping tool.
 
+[Move to top](#contents)
+
 ### Space Visualizer
 
 - [WizTree](https://diskanalyzer.com) - Fast disk space analyzer that scans drives and shows file size distribution. 🪟 ⭐
@@ -783,6 +893,8 @@
 - [JDiskReport](https://www.jgoodies.com/freeware/jdiskreport) - Tool for visualizing disk usage with a variety of charts and graphs. 🪟 🐧
 - [SpaceSniffer](http://www.uderzo.it/main_products/space_sniffer) - Identify large files and folders with an intuitive tree map. 🪟
 - [TreeSize Free](https://jam-software.com/treesize_free) - Visualizes disk space usage in a tree-like structure for easy file management. 🪟
+
+[Move to top](#contents)
 
 ### Trackpad
 

--- a/filter/android-only.md
+++ b/filter/android-only.md
@@ -79,6 +79,8 @@
 
 ## Audio
 
+[Move to top](#contents)
+
 ### Audio Players
 
 - [VLC for Mobile](https://www.videolan.org/vlc) - Supports a wide range of audio formats and offers powerful playback controls. 🤖 🍎
@@ -88,16 +90,22 @@
 - [Retro Music](https://retromusic.app) - A cleen music player made for android with speed controls and multiple themes and customizations. 🤖
 - [Music Speed Changer](https://musicspeedchanger.com) - A Music player with mainly speed controls, eq options, and mores. 🤖 🍎
 
+[Move to top](#contents)
+
 ### Audio Recording
 
 - [Easy Voice Recorder](https://www.digipom.com/portfolio-items/easy-voice-recorder) - High-quality voice recording with playback features for notes and interviews. 🤖 🍎
 - [Dolby On](https://www.dolby.com/apps/dolby-on) - Enhances audio recordings with noise reduction and spatial sound effects. 🤖 🍎
 - [Otter](https://otter.ai) - Transcribes audio in real-time while recording. 🤖 🍎
 
+[Move to top](#contents)
+
 ### DJ Software
 
 - [djay](https://www.algoriddim.com/djay) - Combines music streaming with powerful DJ tools for seamless mixing. 🤖 🍎
 - [Cross DJ Free](https://www.mixvibes.com/cross-dj-free) - Offers beat syncing, looping, and real-time effects. 🤖 🍎
+
+[Move to top](#contents)
 
 ### Music Notation
 
@@ -105,12 +113,16 @@
 - [MuseScore](https://musescore.com) - Open-source notation app for composing and sharing sheet music. 🤖 🍎 🟢
 - [Notion](https://www.presonus.com/products/Notion) - Offers playback of scores using high-quality instrument samples. 🤖 🍎
 
+[Move to top](#contents)
+
 ### Music Production
 
 - [BandLab](https://www.bandlab.com) - Free DAW for recording, mixing, and mastering music with cloud collaboration. 🤖 🍎
 - [FL Studio Mobile](https://www.image-line.com/fl-studio-mobile) - Portable DAW with a full suite of audio editing tools. 🤖 🍎
 - [n-Track Studio](https://ntrack.com) - Multitrack recording app with built-in effects and automation. 🤖 🍎
 
+
+[Move to top](#contents)
 
 ## Browsers
 
@@ -121,7 +133,11 @@
 - [Cromite](https://www.cromite.org) - Privacy-focused Chromium fork with ad-blocking and anti-tracking defaults. 🤖
 - [Microsoft Edge](https://www.microsoft.com/edge/mobile) - Cross-platform browser with sync, privacy controls, and AI-assisted tools. 🤖 🍎
 
+[Move to top](#contents)
+
 ## Communication
+
+[Move to top](#contents)
 
 ### Messaging
 
@@ -130,12 +146,16 @@
 - [WhatsApp](https://www.whatsapp.com) - End-to-end encrypted messaging with voice and video calls. 🤖 🍎
 - [Element](https://element.io) - Secure messaging with Matrix protocol and decentralized features. 🤖 🍎 🟢
 
+[Move to top](#contents)
+
 ### Email Clients
 
 - [Proton Mail](https://proton.me/mail) - Encrypted email with no ads and advanced privacy tools. 🤖 🍎 🟢
 - [BlueMail](https://bluemail.me) - Unified email client with smart push notifications and scheduling. 🤖 🍎
 - [Spark](https://sparkmailapp.com) - Collaboration-focused email app with advanced email triage tools. 🤖 🍎
 - [FairEmail](https://email.faircode.eu) - Lightweight open-source email client with strong privacy features. 🤖 🟢
+
+[Move to top](#contents)
 
 ## Compression and Archiving
 
@@ -144,7 +164,11 @@
 - [WinZip](https://www.winzip.com) - Compress, unzip, and manage files with cloud integration. 🤖 🍎
 - [B1 Archiver](https://b1.org) - Simple file compression tool with multi-format support and encryption. 🤖 🍎
 
+[Move to top](#contents)
+
 ## Customize
+
+[Move to top](#contents)
 
 ### System Customization
 
@@ -152,13 +176,19 @@
 - [KWGT Kustom Widget Maker](https://kustom.rocks) - Create personalized widgets for your home screen. 🤖
 - [Super Status Bar](https://tombayley.dev) - Modify status bar gestures, indicators, and visuals. 🤖
 
+[Move to top](#contents)
+
 ### Wallpaper Tools
 
 - [Backdrops](https://www.backdrops.io) - Offers unique wallpapers with daily updates. 🤖 🍎
 - [Walpy](https://play.google.com/store/apps/details?id=com.feresr.walpy) - Automatic wallpaper changes based on your preferences. 🤖
 - [Resplash](https://unsplash.com) - Access Unsplash’s library for stunning, free wallpapers. 🤖 🍎 🟢
 
+[Move to top](#contents)
+
 ## Data Management
+
+[Move to top](#contents)
 
 ### Copy and Move
 
@@ -166,29 +196,41 @@
 - [CX File Explorer](https://cxfileexplorer.com) - Clean interface for managing files and transferring them to cloud or network storage. 🤖
 - [File Manager+](https://play.google.com/store/apps/details?id=com.alphainventor.filemanager) - Lightweight file manager with support for cloud storage and FTP. 🤖
 
+[Move to top](#contents)
+
 ### Sync and Clone
 
 - [Resilio Sync](https://www.resilio.com) - Securely sync large files across devices with no cloud dependency. 🤖 🍎
 - [Cloner](https://play.google.com/store/apps/details?id=com.genonbeta.TrebleShot) - Transfer files directly between Android devices using Wi-Fi. 🤖
 
+[Move to top](#contents)
+
 ## Developer Tools
 
 - [Termux](https://termux.dev) - Terminal emulator with Linux packages for development. 🤖 🟢
+
+[Move to top](#contents)
 
 ### API Development
 
 - [Postman](https://www.postman.com) - Test, debug, and document APIs with a user-friendly interface. 🤖 🍎
 - [RESTer](https://play.google.com/store/apps/details?id=com.developer.john.rester) - Lightweight REST API testing tool with a clean interface. 🤖
 
+[Move to top](#contents)
+
 ### Database
 
 - [DB Client](https://play.google.com/store/apps/details?id=io.dbclient) - Manage and query databases like MySQL, PostgreSQL, and SQLite. 🤖
 - [SQL Toolbelt](https://play.google.com/store/apps/details?id=dev.balu.sqltool) - Access and query your databases on the go with advanced filtering. 🤖
 
+[Move to top](#contents)
+
 ### Network Analysis
 
 - [PingTools](https://pingtools.org) - Includes ping, traceroute, port scanner, and more for network diagnostics. 🤖
 - [NetMonster](https://play.google.com/store/apps/details?id=cz.mroczis.netmonster) - Displays detailed information about cellular networks. 🤖
+
+[Move to top](#contents)
 
 ### Game Engines
 
@@ -196,11 +238,17 @@
 - [Pocket Code](https://www.catrobat.org) - Build simple games and apps using visual programming. 🤖 🍎 🟢
 - [GDevelop](https://gdevelop.io) - Open-source game engine to create games without coding. 🤖 🟢
 
+[Move to top](#contents)
+
 ### Virtualization
 
 - [Linux Deploy](https://github.com/meefik/linuxdeploy) - Install and run Linux distributions on your mobile device. 🤖 🟢
 
+[Move to top](#contents)
+
 ## Documents
+
+[Move to top](#contents)
 
 ### Office Suites
 
@@ -208,16 +256,22 @@
 - [WPS Office](https://www.wps.com) - All-in-one office suite with PDF tools and cloud sync. 🤖 🍎
 - [Polaris Office](https://www.polarisoffice.com) - Lightweight office suite with cross-device syncing and templates. 🤖 🍎
 
+[Move to top](#contents)
+
 ### E-book
 
 - [Kobo Books](https://www.kobo.com) - Read eBooks and audiobooks with an integrated store. 🤖 🍎
 - [Lithium](https://play.google.com/store/apps/details?id=com.faultexception.reader) - Lightweight and ad-free eBook reader for EPUB files. 🤖
+
+[Move to top](#contents)
 
 ### PDF Tools
 
 - [Adobe Acrobat Reader](https://www.adobe.com/acrobat/mobile-app.html) - View, annotate, and sign PDFs with advanced tools. 🤖 🍎
 - [Xodo PDF Reader](https://www.xodo.com) - Edit, annotate, and collaborate on PDFs in real time. 🤖 🍎
 - [Foxit PDF Reader](https://www.foxit.com/pdf-reader-mobile) - Lightweight PDF viewer with editing and security tools. 🤖 🍎
+
+[Move to top](#contents)
 
 ## Note Taking
 
@@ -226,21 +280,29 @@
 - [Joplin](https://joplinapp.org) - Open-source note-taking app with end-to-end encryption. 🤖 🍎 🟢
 - [Google Keep](https://keep.google.com) - Simple and colorful note-taking app with reminders. 🤖 🍎
 
+[Move to top](#contents)
+
 ## Text Editors
 
 - [QuickEdit](https://play.google.com/store/apps/details?id=com.rhmsoft.edit) - Lightweight text editor for coding with syntax highlighting. 🤖
 - [Dcoder](https://dcoder.tech) - Mobile IDE supporting multiple programming languages. 🤖 🍎
 - [AIDE](https://play.google.com/store/apps/details?id=com.aide.ui) - Mobile IDE to code and build Android apps on the go. 🤖
 
+[Move to top](#contents)
+
 ## Finance
 
 - [BeeCount](https://github.com/TNT-Likely/BeeCount/blob/main/README_EN.md) - Privacy-first cross-platform expense tracker with self-hostable cloud sync (BeeCount Cloud, iCloud, Supabase, WebDAV, S3) and offline-first design. 🤖 🍎
+
+[Move to top](#contents)
 
 ## Download Managers
 
 - [IDM](https://play.google.com/store/apps/details?id=com.downloadmanager.app&hl=en) - Accelerates downloads with advanced scheduling and queuing. 🤖
 - [ADM (Advanced Download Manager)](https://play.google.com/store/apps/details?id=com.dv.adm) - Powerful download manager with split download support. 🤖
 - [MyJDownloader](https://my.jdownloader.org) - Remotely manage downloads from your desktop JDownloader. 🤖 🍎
+
+[Move to top](#contents)
 
 ## Graphics Tools
 
@@ -249,12 +311,18 @@
 - [Snapseed](https://support.google.com/snapseed) - Powerful photo editing app with fine-tuning tools. 🤖 🍎
 - [Adobe Express](https://www.adobe.com/express) - Create graphics and collages with Adobe’s design tools. 🤖 🍎
 
+[Move to top](#contents)
+
 ## 3D Modeling and Animation
 
 - [Sculpt+](https://play.google.com/store/apps/details?id=com.endvoid.SculptPlus) - Create 3D models with intuitive sculpting tools. 🤖
 - [MediBang Paint](https://medibangpaint.com/en) - 2D art and illustration tool with layers and brushes. 🤖 🍎
 
+[Move to top](#contents)
+
 ## Security
+
+[Move to top](#contents)
 
 ### Antivirus
 
@@ -262,11 +330,15 @@
 - [Bitdefender Mobile Security](https://www.bitdefender.com/solutions/mobile-security.html) - Lightweight antivirus with advanced web protection. 🤖 🍎
 - [Sophos Intercept X](https://www.sophos.com/en-us/free-tools/intercept-x-for-mobile.aspx) - Free antivirus with app scanning and web filtering. 🤖 🍎
 
+[Move to top](#contents)
+
 ### Password Managers
 
 - [Bitwarden](https://bitwarden.com) - Open-source password manager with end-to-end encryption. 🤖 🍎 🟢
 - [LastPass](https://www.lastpass.com) - Store and autofill passwords securely across devices. 🤖 🍎
 - [1Password](https://1password.com) - Advanced password management with family sharing options. 🤖 🍎
+
+[Move to top](#contents)
 
 ## Image Viewers
 
@@ -275,6 +347,8 @@
 - [A+ Gallery](https://play.google.com/store/apps/details?id=com.atomicadd.filedir) - Organize and view photos by date, location, and albums. 🤖
 - [Google Photos](https://photos.google.com) - Manage and sync photos with powerful search and cloud backup. 🤖 🍎
 
+[Move to top](#contents)
+
 ## Remote Access
 
 - [TeamViewer](https://www.teamviewer.com) - Control computers and mobile devices remotely with ease. 🤖 🍎
@@ -282,7 +356,11 @@
 - [Chrome Remote Desktop](https://remotedesktop.google.com) - Securely access your desktop from mobile. 🤖 🍎
 - [Splashtop Personal](https://www.splashtop.com/personal) - Stream your desktop to mobile devices with high quality. 🤖 🍎
 
+[Move to top](#contents)
+
 ## Video
+
+[Move to top](#contents)
 
 ### Video Editors
 
@@ -291,6 +369,8 @@
 - [VivaVideo](https://www.quvideo.com) - Simple video editing app with a variety of templates and effects. 🤖 🍎
 - [Adobe Premiere Rush](https://www.adobe.com/products/premiere-rush.html) - Mobile version of Premiere Pro for editing and sharing videos. 🤖 🍎
 
+[Move to top](#contents)
+
 ### Video Players
 
 - [MX Player](https://www.mxplayer.in) - Supports a wide range of video formats with advanced playback options. 🤖 🍎
@@ -298,16 +378,22 @@
 - [BSPlayer](https://www.bsplayer.com) - Lightweight video player with subtitle support and hardware acceleration. 🤖 🍎
 - [GOM Player](https://www.gomlab.com) - Versatile video player with a large range of supported formats. 🤖 🍎
 
+[Move to top](#contents)
+
 ### Video Streaming and Recording
 
 - [Twitch](https://www.twitch.tv) - Stream and watch live gaming content from mobile devices. 🤖 🍎
 - [YouTube](https://www.youtube.com) - Stream and upload videos to the world’s largest video platform. 🤖 🍎
 - [OBS Studio (via Streamlabs)](https://streamlabs.com) - Stream or record gameplay, tutorials, and live events. 🤖 🍎
 
+[Move to top](#contents)
+
 ### Video Converters and Compressors
 
 - [VidCompact](https://play.google.com/store/apps/details?id=com.xvideostudio.videoeditor) - Convert and compress videos while maintaining quality. 🤖
 - [Video Converter](https://play.google.com/store/apps/details?id=com.tecno.video.converter) - Easy video format conversion and compression. 🤖
+
+[Move to top](#contents)
 
 ## VPN and Proxy Tools
 
@@ -317,26 +403,38 @@
 - [Windscribe](https://windscribe.com) - Privacy-focused VPN with a free option and wide server coverage. 🤖 🍎 🟢
 - [Betternet](https://www.betternet.co) - Fast, free VPN for browsing securely and privately. 🤖 🍎
 
+[Move to top](#contents)
+
 ## Health and Wellness
 
 - [Paula](https://trypaula.com) - Free AI mental health companion using CBT and DBT techniques, with voice sessions, mood tracking, and journaling. 🤖 🍎
 - [Euki](https://eukiapp.org) - Privacy-first period tracker with sexual health resources and local-only data storage. 🤖 🍎 [🟢](https://github.com/Euki-Inc/Euki-Android)
 
+[Move to top](#contents)
+
 ## Utility
+
+[Move to top](#contents)
 
 ### Clipboard Management
 
 - [Clipper](https://play.google.com/store/apps/details?id=com.rojekti.clipper) - Clipboard manager with history and easy access to copied content. 🤖
+
+[Move to top](#contents)
 
 ### Metadata
 
 - [Exif Pilot](https://www.exifpilot.com) - View and edit metadata for images, videos, and audio files. 🤖 🍎
 - [Photo Exif Editor](https://play.google.com/store/apps/details?id=com.flq.phototool) - Edit and remove EXIF data from photos. 🤖
 
+[Move to top](#contents)
+
 ### Window Management
 
 - [Split Screen](https://play.google.com/store/apps/details?id=com.farmerbb.splitwindow) - Use two apps simultaneously in split-screen mode. 🤖
 - [Floating Apps](https://play.google.com/store/apps/details?id=com.lv.float.apps) - Open multiple apps as floating windows on the screen. 🤖
+
+[Move to top](#contents)
 
 ### File Management
 
@@ -344,16 +442,22 @@
 - [CX File Explorer](https://cxfileexplorer.com) - Clean interface for managing files and transferring them to cloud or network storage. 🤖
 - [File Manager +](https://play.google.com/store/apps/details?id=com.alphainventor.filemanager) - Lightweight file manager with cloud support and FTP. 🤖
 
+[Move to top](#contents)
+
 ### Application Management
 
 - [AppMgr III](https://play.google.com/store/apps/details?id=com.a0soft.gphone.app2sd) - Move apps to external storage and manage installed apps. 🤖
 - [Titanium Backup](https://play.google.com/store/apps/details?id=com.keramidas.TitaniumBackup) - Advanced app backup and restore tool (root required). 🤖
+
+[Move to top](#contents)
 
 ### Screenshot
 
 - [Screenshot Easy](https://play.google.com/store/apps/details?id=com.icecoldapps.screenshot) - Simple app to take screenshots with multiple capture methods. 🤖
 - [Screenshot Capture](https://play.google.com/store/apps/details?id=com.screenshot.capture) - Capture screenshots with one tap and edit them immediately. 🤖
 - [LongShot](https://play.google.com/store/apps/details?id=com.tackapp.longshot) - Take long screenshots of webpages or chat conversations. 🤖
+
+[Move to top](#contents)
 
 ### Space Visualizer
 

--- a/filter/iOS-only.md
+++ b/filter/iOS-only.md
@@ -79,11 +79,15 @@
 
 ## Audio
 
+[Move to top](#contents)
+
 ### Audio Players
 
 - [VLC for Mobile](https://www.videolan.org/vlc) - Supports a wide range of audio formats and offers powerful playback controls. 🤖 🍎
 - [Foobar2000](https://foobar2000.org) - Minimalist player supporting advanced playback features and customization. 🤖 🍎
 - [Music Speed Changer](https://musicspeedchanger.com) - A Music player with mainly speed controls, eq options, and mores. 🤖 🍎
+
+[Move to top](#contents)
 
 ### Audio Recording
 
@@ -91,17 +95,23 @@
 - [Dolby On](https://www.dolby.com/apps/dolby-on) - Enhances audio recordings with noise reduction and spatial sound effects. 🤖 🍎
 - [Otter](https://otter.ai) - Transcribes audio in real-time while recording. 🤖 🍎
 
+[Move to top](#contents)
+
 ### DJ Software
 
 - [djay](https://www.algoriddim.com/djay) - Combines music streaming with powerful DJ tools for seamless mixing. 🤖 🍎
 - [Cross DJ Free](https://www.mixvibes.com/cross-dj-free) - Offers beat syncing, looping, and real-time effects. 🤖 🍎
 - [Pacemaker](https://pacemaker.net) - Intuitive DJ app with AI-assisted mixing for beginners and professionals. 🍎
 
+[Move to top](#contents)
+
 ### Music Notation
 
 - [Flat](https://flat.io) - Easy-to-use music notation app with real-time collaboration features. 🤖 🍎
 - [MuseScore](https://musescore.com) - Open-source notation app for composing and sharing sheet music. 🤖 🍎 🟢
 - [Notion](https://www.presonus.com/products/Notion) - Offers playback of scores using high-quality instrument samples. 🤖 🍎
+
+[Move to top](#contents)
 
 ### Music Production
 
@@ -110,6 +120,8 @@
 - [n-Track Studio](https://ntrack.com) - Multitrack recording app with built-in effects and automation. 🤖 🍎
 
 
+[Move to top](#contents)
+
 ## Browsers
 
 - [Firefox](https://www.mozilla.org/firefox) - Privacy-focused browser with customizable extensions and tracking protection. 🤖 🍎 🟢
@@ -117,7 +129,11 @@
 - [DuckDuckGo Privacy Browser](https://duckduckgo.com/app) - Focuses on privacy with no tracking and private search. 🤖 🍎
 - [Opera](https://www.opera.com/mobile) - Built-in ad blocker, VPN, and offline file sharing. 🤖 🍎
 
+[Move to top](#contents)
+
 ## Communication
+
+[Move to top](#contents)
 
 ### Messaging
 
@@ -126,11 +142,15 @@
 - [WhatsApp](https://www.whatsapp.com) - End-to-end encrypted messaging with voice and video calls. 🤖 🍎
 - [Element](https://element.io) - Secure messaging with Matrix protocol and decentralized features. 🤖 🍎 🟢
 
+[Move to top](#contents)
+
 ### Email Clients
 
 - [Proton Mail](https://proton.me/mail) - Encrypted email with no ads and advanced privacy tools. 🤖 🍎 🟢
 - [BlueMail](https://bluemail.me) - Unified email client with smart push notifications and scheduling. 🤖 🍎
 - [Spark](https://sparkmailapp.com) - Collaboration-focused email app with advanced email triage tools. 🤖 🍎
+
+[Move to top](#contents)
 
 ## Compression and Archiving
 
@@ -139,11 +159,17 @@
 - [WinZip](https://www.winzip.com) - Compress, unzip, and manage files with cloud integration. 🤖 🍎
 - [B1 Archiver](https://b1.org) - Simple file compression tool with multi-format support and encryption. 🤖 🍎
 
+[Move to top](#contents)
+
 ## Customize
+
+[Move to top](#contents)
 
 ### System Customization
 
 - [Icon Themer](https://apps.apple.com/us/app/icon-themer/id1534126062) - Customize app icons for a unique home screen look. 🍎
+
+[Move to top](#contents)
 
 ### Wallpaper Tools
 
@@ -151,41 +177,63 @@
 - [Vellum](https://www.getvellum.com) - High-quality curated wallpapers with minimalistic design options. 🍎
 - [Resplash](https://unsplash.com) - Access Unsplash’s library for stunning, free wallpapers. 🤖 🍎 🟢
 
+[Move to top](#contents)
+
 ## Data Management
+
+[Move to top](#contents)
 
 ### Copy and Move
 
 - [FileApp](https://www.digidna.net/fileapp) - File manager to organize and transfer files between devices. 🍎
+
+[Move to top](#contents)
 
 ### Sync and Clone
 
 - [Resilio Sync](https://www.resilio.com) - Securely sync large files across devices with no cloud dependency. 🤖 🍎
 - [Documents by Readdle](https://readdle.com/documents) - Manage files and sync with cloud storage services like Google Drive and Dropbox. 🍎
 
+[Move to top](#contents)
+
 ## Developer Tools
 
+
+[Move to top](#contents)
 
 ### API Development
 
 - [Postman](https://www.postman.com) - Test, debug, and document APIs with a user-friendly interface. 🤖 🍎
 
+[Move to top](#contents)
+
 ### Database
 
 - [DataBase Client](https://apps.apple.com/us/app/database-client/id1439482410) - Manage and query MySQL and PostgreSQL databases on iOS. 🍎
+
+[Move to top](#contents)
 
 ### Network Analysis
 
 - [Network Analyzer](https://apps.apple.com/us/app/network-analyzer/id562315041) - Diagnose Wi-Fi and network problems with detailed insights. 🍎
 
+[Move to top](#contents)
+
 ### Game Engines
 
 - [Pocket Code](https://www.catrobat.org) - Build simple games and apps using visual programming. 🤖 🍎 🟢
+
+[Move to top](#contents)
 
 ### Virtualization
 
 - [UTM](https://github.com/utmapp/UTM) - Load virtual machines on your iPhone or iPad. 🍎 🟢
 
+[Move to top](#contents)
+
 ## Documents
+
+[Move to top](#contents)
 
 ### Office Suites
 
@@ -193,16 +241,22 @@
 - [WPS Office](https://www.wps.com) - All-in-one office suite with PDF tools and cloud sync. 🤖 🍎
 - [Polaris Office](https://www.polarisoffice.com) - Lightweight office suite with cross-device syncing and templates. 🤖 🍎
 
+[Move to top](#contents)
+
 ### E-book
 
 - [Kobo Books](https://www.kobo.com) - Read eBooks and audiobooks with an integrated store. 🤖 🍎
 - [Apple Books](https://www.apple.com/apple-books) - Manage and read eBooks with built-in audiobook features. 🍎
+
+[Move to top](#contents)
 
 ### PDF Tools
 
 - [Adobe Acrobat Reader](https://www.adobe.com/acrobat/mobile-app.html) - View, annotate, and sign PDFs with advanced tools. 🤖 🍎
 - [Xodo PDF Reader](https://www.xodo.com) - Edit, annotate, and collaborate on PDFs in real time. 🤖 🍎
 - [Foxit PDF Reader](https://www.foxit.com/pdf-reader-mobile) - Lightweight PDF viewer with editing and security tools. 🤖 🍎
+
+[Move to top](#contents)
 
 ## Note Taking
 
@@ -214,19 +268,27 @@
 - [不拖 (Butuo)](https://apps.apple.com/app/id6761042128) - Minimalist to-do app with local-only storage. No account, no server, no sync. Free. 🍎
 - [DailyVox](https://getdailyvox.com) - Free AI voice diary with on-device transcription, mood tracking, and Digital Twin. No cloud, no accounts. 🍎 [🟢](https://github.com/intrepidkarthi/dailyvox)
 
+[Move to top](#contents)
+
 ## Text Editors
 
 - [Dcoder](https://dcoder.tech) - Mobile IDE supporting multiple programming languages. 🤖 🍎
 - [Textastic](https://textasticapp.com) - Code and text editor with syntax support for numerous languages. 🍎
 
+[Move to top](#contents)
+
 ## Finance
 
 - [BeeCount](https://github.com/TNT-Likely/BeeCount/blob/main/README_EN.md) - Privacy-first cross-platform expense tracker with self-hostable cloud sync (BeeCount Cloud, iCloud, Supabase, WebDAV, S3) and offline-first design. 🤖 🍎
+
+[Move to top](#contents)
 
 ## Download Managers
 
 - [iDownloader](https://apps.apple.com/us/app/idownloader-pro/id657087236) - Download manager with browser integration and video support. 🍎
 - [MyJDownloader](https://my.jdownloader.org) - Remotely manage downloads from your desktop JDownloader. 🤖 🍎
+
+[Move to top](#contents)
 
 ## Graphics Tools
 
@@ -235,13 +297,19 @@
 - [Snapseed](https://support.google.com/snapseed) - Powerful photo editing app with fine-tuning tools. 🤖 🍎
 - [Adobe Express](https://www.adobe.com/express) - Create graphics and collages with Adobe’s design tools. 🤖 🍎
 
+[Move to top](#contents)
+
 ## 3D Modeling and Animation
 
 - [Shapr3D](https://www.shapr3d.com) - CAD modeling app with professional-grade features. 🍎
 - [Putty 3D](https://apps.apple.com/us/app/putty-3d/id1070986787) - Mobile 3D sculpting app for simple and detailed creations. 🍎
 - [MediBang Paint](https://medibangpaint.com/en) - 2D art and illustration tool with layers and brushes. 🤖 🍎
 
+[Move to top](#contents)
+
 ## Security
+
+[Move to top](#contents)
 
 ### Antivirus
 
@@ -249,15 +317,21 @@
 - [Bitdefender Mobile Security](https://www.bitdefender.com/solutions/mobile-security.html) - Lightweight antivirus with advanced web protection. 🤖 🍎
 - [Sophos Intercept X](https://www.sophos.com/en-us/free-tools/intercept-x-for-mobile.aspx) - Free antivirus with app scanning and web filtering. 🤖 🍎
 
+[Move to top](#contents)
+
 ### Password Managers
 
 - [Bitwarden](https://bitwarden.com) - Open-source password manager with end-to-end encryption. 🤖 🍎 🟢
 - [LastPass](https://www.lastpass.com) - Store and autofill passwords securely across devices. 🤖 🍎
 - [1Password](https://1password.com) - Advanced password management with family sharing options. 🤖 🍎
 
+[Move to top](#contents)
+
 ## Image Viewers
 
 - [Google Photos](https://photos.google.com) - Manage and sync photos with powerful search and cloud backup. 🤖 🍎
+
+[Move to top](#contents)
 
 ## Remote Access
 
@@ -266,7 +340,11 @@
 - [Chrome Remote Desktop](https://remotedesktop.google.com) - Securely access your desktop from mobile. 🤖 🍎
 - [Splashtop Personal](https://www.splashtop.com/personal) - Stream your desktop to mobile devices with high quality. 🤖 🍎
 
+[Move to top](#contents)
+
 ## Video
+
+[Move to top](#contents)
 
 ### Video Editors
 
@@ -275,6 +353,8 @@
 - [VivaVideo](https://www.quvideo.com) - Simple video editing app with a variety of templates and effects. 🤖 🍎
 - [Adobe Premiere Rush](https://www.adobe.com/products/premiere-rush.html) - Mobile version of Premiere Pro for editing and sharing videos. 🤖 🍎
 
+[Move to top](#contents)
+
 ### Video Players
 
 - [MX Player](https://www.mxplayer.in) - Supports a wide range of video formats with advanced playback options. 🤖 🍎
@@ -282,15 +362,21 @@
 - [BSPlayer](https://www.bsplayer.com) - Lightweight video player with subtitle support and hardware acceleration. 🤖 🍎
 - [GOM Player](https://www.gomlab.com) - Versatile video player with a large range of supported formats. 🤖 🍎
 
+[Move to top](#contents)
+
 ### Video Streaming and Recording
 
 - [Twitch](https://www.twitch.tv) - Stream and watch live gaming content from mobile devices. 🤖 🍎
 - [YouTube](https://www.youtube.com) - Stream and upload videos to the world’s largest video platform. 🤖 🍎
 - [OBS Studio (via Streamlabs)](https://streamlabs.com) - Stream or record gameplay, tutorials, and live events. 🤖 🍎
 
+[Move to top](#contents)
+
 ### Video Converters and Compressors
 
 - [iConv](https://apps.apple.com/us/app/iconv-video-converter/id1102651966) - Convert videos to different formats with simple controls. 🍎
+
+[Move to top](#contents)
 
 ## VPN and Proxy Tools
 
@@ -300,34 +386,52 @@
 - [Windscribe](https://windscribe.com) - Privacy-focused VPN with a free option and wide server coverage. 🤖 🍎 🟢
 - [Betternet](https://www.betternet.co) - Fast, free VPN for browsing securely and privately. 🤖 🍎
 
+[Move to top](#contents)
+
 ## Health and Wellness
 
 - [Paula](https://trypaula.com) - Free AI mental health companion using CBT and DBT techniques, with voice sessions, mood tracking, and journaling. 🤖 🍎
 - [Euki](https://eukiapp.org) - Privacy-first period tracker with sexual health resources and local-only data storage. 🤖 🍎 [🟢](https://github.com/Euki-Inc/Euki-Android)
 
+[Move to top](#contents)
+
 ## Utility
+
+[Move to top](#contents)
 
 ### Clipboard Management
 
 - [Clips](https://apps.apple.com/us/app/clips/id1218408435) - Clipboard manager that organizes and stores copied text and images. 🍎
 - [CopyClip](https://apps.apple.com/us/app/copyclip/id452100581) - Simple clipboard manager to store and paste text snippets. 🍎
 
+[Move to top](#contents)
+
 ### Metadata
 
 - [Exif Pilot](https://www.exifpilot.com) - View and edit metadata for images, videos, and audio files. 🤖 🍎
 - [Metapho](https://apps.apple.com/us/app/metapho/id979247655) - View, edit, and remove metadata from images. 🍎
 
+[Move to top](#contents)
+
 ### Window Management
 
+
+[Move to top](#contents)
 
 ### File Management
 
 
+[Move to top](#contents)
+
 ### Application Management
 
 
+[Move to top](#contents)
+
 ### Screenshot
 
+
+[Move to top](#contents)
 
 ### Space Visualizer
 

--- a/filter/linux-only.md
+++ b/filter/linux-only.md
@@ -87,19 +87,27 @@
 
 - [JACK Audio](https://jackaudio.org) - Audio server for routing and mixing sound between programs. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ### Audio Players
 
 - [Audacious](https://github.com/audacious-media-player/audacious) - Lightweight audio player for simple music playback. 🪟 🐧 🟢
 - [Strawberry Music Player](https://strawberrymusicplayer.org) - Music player for organizing and playing your audio collection. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ### Audio Recording
 
 - [Audacity](https://audacityteam.org/download) - Audio editor for recording and editing sounds. 🪟 🍎 🐧 🟢 ⭐
 - [Ocenaudio](https://ocenaudio.com) - Easy-to-use audio editor for recording and analyzing sounds. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ### DJ Software
 
 - [Mixxx](https://mixxx.org) - DJ software for live mixing and beatmatching with controller support. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ### Music Notation
 
@@ -108,6 +116,8 @@
 - [Frescobaldi](https://frescobaldi.org) - Editor for LilyPond to create music scores quickly. 🪟 🍎 🐧
 - [LilyPond](https://lilypond.org) - Music notation program for creating high-quality sheet music. 🪟 🍎 🐧
 - [MuseScore](https://musescore.org) - Software for creating, playing, and sharing sheet music. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ### Music Production
 
@@ -118,6 +128,8 @@
 - [Qtractor](https://qtractor.org) - Multi-track DAW for Linux for audio and MIDI recording. 🐧
 - [Stargate DAW](https://github.com/stargatedaw/stargate) - Innovation-first DAW, instrument and effect plugins. 🪟 🍎 🐧 🟢
 - [Tracktion T7](https://tracktion.com/products/t7-daw) - DAW for music production with advanced editing features. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ## Browsers
 
@@ -139,7 +151,11 @@
 - [Vivaldi](https://vivaldi.com) - Customizable browser putting you in control. 🪟 🍎 🐧
 - [Zen Browser](https://zen-browser.app) - Beautifully designed, privacy-focused browser with custom mods. 🪟 🍎 🐧 [🟢](https://github.com/zen-browser/desktop)
 
+[Move to top](#contents)
+
 ## Communication
+
+[Move to top](#contents)
 
 ### Messaging
 
@@ -150,6 +166,8 @@
 - [Viber](https://viber.com) - Free messaging app with text, voice, video calls, and file sharing. 🪟 🍎 🐧
 - [Microsoft Teams](https://microsoft.com/en-us/microsoft-teams/group-chat-software) - Team communication platform with chat, file sharing, and video conferencing. 🪟 🍎 🐧
 - [Skype](https://skype.com) - Messaging and video call service supporting text, voice, and video. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ### Email Clients
 
@@ -165,14 +183,22 @@
 - [ThunderBird](https://thunderbird.net) - Email client for easier management. 🪟 🍎 🐧 🟢
 - [Tutanota](https://tutanota.com) - Encrypted service focused on privacy. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ## Compression and Archiving
 
 - [PeaZip](https://peazip.github.io) - Archive manager supporting 180+ formats with encryption and compression. 🪟 🐧 🟢
 
+[Move to top](#contents)
+
 ## Customize
+
+[Move to top](#contents)
 
 ### System Customization
 
+
+[Move to top](#contents)
 
 ### Wallpaper Tools
 
@@ -180,16 +206,24 @@
 - [ScreenPlay](https://github.com/kelteseth/ScreenPlay) - Wallpaper and widget engine. 🪟 🐧 🟢
 - [Variety](https://github.com/varietywalls/variety) - Wallpaper changer with features for downloading and managing wallpapers. 🐧 🟢
 
+[Move to top](#contents)
+
 ## Data Management
+
+[Move to top](#contents)
 
 ### Copy and Move
 
+
+[Move to top](#contents)
 
 ### Sync and Clone
 
 - [FreeFileSync](https://freefilesync.org) - Tool for comparing and syncing files or folders. 🪟 🍎 🐧 🟢 ⭐
 - [rclone](https://rclone.org) - Command-line tool for managing and syncing files with cloud storage. 🪟 🍎 🐧
 - [Syncthing](https://github.com/syncthing/syncthing) - Continuous file synchronization for multiple computers. 🪟 🍎 🐧 🟢
+
+[Move to top](#contents)
 
 ## Developer Tools
 
@@ -199,6 +233,8 @@
 - [Ollama](https://ollama.com) - Runs and manages local AI models with desktop and command-line tools. 🪟 🍎 🐧 [🟢](https://github.com/ollama/ollama)
 - [Android Studio](https://developer.android.com/studio) - Official IDE for Android development with emulator, code editor, and build tools. 🪟 🍎 🐧
 - [WezTerm](https://wezterm.org) - GPU-accelerated terminal emulator and multiplexer with tabs, panes, SSH, and Lua configuration. 🪟 🍎 🐧 [🟢](https://github.com/wezterm/wezterm)
+
+[Move to top](#contents)
 
 ### API Development
 
@@ -214,11 +250,15 @@
 - [SoapUI Open Source](https://soapui.org) - For testing REST and SOAP APIs with scripting support. 🪟 🍎 🐧 [🟢](https://github.com/SmartBear/soapui)
 - [Yaak](https://yaak.app) - An offline and Git friendly API tester for HTTP, GraphQL, WebSockets, SSE, and gRPC. 🪟 🍎 🐧 [🟢](https://github.com/mountain-loop/yaak)
 
+[Move to top](#contents)
+
 ### Database
 
 - [DBeaver](https://dbeaver.io) - Universal database tool for SQL databases like MySQL, MariaDB, PostgreSQL, SQLite, Apache Family, and more. 🪟 🍎 🐧 ⭐
 - [Beekeeper Studio](https://beekeeperstudio.io) - Modern, lightweight SQL client supporting MySQL, Postgres, SQLite, SQL Server, etc. 🪟 🍎 🐧
 - [DB Browser for SQLite](https://sqlitebrowser.org) - Visual tool for creating, browsing, and editing SQLite database files. 🪟 🍎 🐧 [🟢](https://github.com/sqlitebrowser/sqlitebrowser)
+
+[Move to top](#contents)
 
 ### Network Analysis
 
@@ -227,6 +267,8 @@
 - [Charles](https://charlesproxy.com) - Debugging proxy to view HTTP and HTTPS traffic. 🪟 🍎 🐧
 - [mitmproxy](https://mitmproxy.org) - Interactive HTTP proxy for debugging and penetration testing. 🪟 🍎 🐧 [🟢](https://github.com/mitmproxy/mitmproxy)
 - [Sniffnet](https://sniffnet.net) - Tool for monitoring and analyzing network traffic. 🪟 🍎 🐧 [🟢](https://github.com/GyulyVGC/sniffnet)
+
+[Move to top](#contents)
 
 ### Game Engines
 
@@ -248,6 +290,8 @@
 - [Tiled](https://mapeditor.org) - Level editor for creating tile-based game maps, used with other engines. 🪟 🍎 🐧 🟢
 - [Unity](https://unity.com) - Popular game engine for creating both 2D and 3D games, with an intuitive interface and wide asset store. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ### Virtualization
 
 - [Docker](https://docker.com) - Containerization platform for operating-system-level virtualization. 🪟 🍎 🐧 🟢 ⭐
@@ -259,8 +303,12 @@
 - [Vagrant](https://vagrantup.com) - Tool for managing reproducible development environments using virtual machines. 🪟 🍎 🐧 🟢
 - [VMWare Workstation](https://vmware.com/products/desktop-hypervisor/workstation-and-fusion) - Virtualization software with advanced features. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ## Documents
 
+
+[Move to top](#contents)
 
 ### Office Suites
 
@@ -275,6 +323,8 @@
 - [WPS Office](https://wps.com) - Lightweight office suite compatible with MS file formats. 🪟 🍎 🐧
 
 
+[Move to top](#contents)
+
 ### E-book
 
 - [Calibre](https://calibre-ebook.com) - Powerful e-book manager. 🪟 🍎 🐧 [🟢](https://github.com/kovidgoyal/calibre) ⭐
@@ -285,6 +335,8 @@
 - [Scribus](https://www.scribus.net) - Layout and publishing software. 🪟 🍎 🐧 [🟢](https://github.com/scribusproject/scribus)
 - [Sigil](https://sigil-ebook.com) - EPUB editor. 🪟 🍎 🐧 [🟢](https://github.com/Sigil-Ebook/Sigil)
 
+[Move to top](#contents)
+
 ### PDF Tools
 
 - [MuPDF](https://mupdf.com) - Powerful PDF viewer. 🪟 🐧 [🟢](https://github.com/ArtifexSoftware/mupdf)
@@ -293,6 +345,8 @@
 - [qpdfview](https://launchpad.net/qpdfview) - Tabbed document viewer. 🐧 [🟢](https://github.com/bendikro/qpdfview)
 - [Xournal++](https://xournalpp.github.io) - Handwriting and annotation tool for PDFs. 🪟 🍎 🐧 [🟢](https://github.com/xournalpp/xournalpp)
 - [PDFsam](https://pdfsam.org) - Extract pages, split, merge, mix and rotate PDF files. 🪟 🍎 🐧 [🟢](https://github.com/torakiki/pdfsam)
+
+[Move to top](#contents)
 
 ## Note Taking
 
@@ -304,6 +358,8 @@
 - [Simplenote](https://simplenote.com) - Minimalist note-taking app that syncs across devices. 🪟 🍎 🐧 [🟢](https://github.com/Automattic/simplenote-electron)
 - [qnote](https://github.com/Omibranch/qnote) - Minimal frameless notepad with Markdown preview, real PDF export via Typst, OCR via Tesseract, and automatic version history. 🐧 [🟢](https://github.com/Omibranch/qnote)
 - [fylepad](https://fylepad.vercel.app) - Lightweight notepad with powerful rich-text editing. 🪟 🍎 🐧 [🟢](https://github.com/imrofayel/fylepad)
+
+[Move to top](#contents)
 
 ## Text Editors
 
@@ -325,6 +381,8 @@
 - [Zed](https://zed.dev) - High-performance, collaborative editor designed for speed, real-time collaboration, and custom workflows. 🍎 🐧 [🟢](https://github.com/zed-industries/zed)
 - [VSCodium](https://vscodium.com) - Community-built VS Code binaries without Microsoft branding, telemetry, or licensing changes. 🪟 🍎 🐧 [🟢](https://github.com/VSCodium/vscodium)
 
+[Move to top](#contents)
+
 ## Download Managers
 
 - [AB Download Manager](https://abdownloadmanager.com) - Easily download files from anywhere. 🪟 🐧 [🟢](https://github.com/amir1376/ab-download-manager) ⭐
@@ -336,6 +394,8 @@
 - [Xtreme Download Manager (XDM)](https://xtremedownloadmanager.com) - Powerful tool to increase download speed. 🪟 🍎 🐧 [🟢](https://github.com/subhra74/xdm)
 - [Transmission](https://transmissionbt.com) - Lightweight BitTorrent client with native desktop, daemon, and web interfaces. 🪟 🍎 🐧 [🟢](https://github.com/transmission/transmission)
 
+[Move to top](#contents)
+
 ## Games
 
 - [Steam](https://store.steampowered.com) - Platform for buying and playing PC games. 🪟 🍎 🐧 ⭐
@@ -344,16 +404,22 @@
 - [Lutris](https://lutris.net) - Open-source game manager for Linux. 🐧 [🟢](https://github.com/lutris/lutris)
 - [ProtonUp-Qt](https://davidotek.github.io/protonup-qt) - Tool for managing Proton/Wine compatibility. 🐧 [🟢](https://github.com/DavidoTek/ProtonUp-Qt)
 
+[Move to top](#contents)
+
 ### Cloud Gaming
 
 - [Antstream Arcade](https://www.antstream.com) - Free tier with retro games playable via the cloud. 🪟 🍎 🐧
 - [Boosteroid](https://boosteroid.com) - Free plan available for limited game streaming. 🪟 🍎 🐧
 - [NVIDIA GeForce NOW](https://www.nvidia.com/en-us/geforce-now) - Free tier for streaming supported games from the cloud. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ## Mobile Emulators
 
 - [Genymotion](https://genymotion.com) - Android emulator with advanced features for developers and gamers. 🪟 🍎 🐧
 - [Waydroid](https://waydro.id) - Container-based approach to boot a full Android system. 🐧 [🟢](https://github.com/waydroid/waydroid)
+
+[Move to top](#contents)
 
 ## Other Emulators
 
@@ -373,6 +439,8 @@
 - [MelonDS](https://melonds.kuribo64.net) - Nintendo DS emulator with accurate performance and Wi-Fi support. 🪟 🍎 🐧
 - [BSNES](https://bsnes.dev) - SNES emulator with cycle-accurate emulation for high compatibility. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ## Graphics Tools
 
 - [GIMP](https://gimp.org) - Versatile image editor for tasks like photo manipulation and graphic design. 🪟 🍎 🐧 🟢 ⭐
@@ -389,6 +457,8 @@
 - [MagicaVoxel](https://ephtracy.github.io) - Lightweight voxel editor and interactive path tracing renderer for 3D models. 🪟 🍎 🐧
 - [Pencil2D](https://pencil2d.org) - Simple and intuitive tool for creating 2D hand-drawn animations. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ## 3D Modeling and Animation
 
 - [Blender](https://blender.org) - 3D creation tool supporting modeling, animation, rendering, video editing, and more. 🪟 🍎 🐧 🟢 ⭐
@@ -397,13 +467,19 @@
 - [OpenSCAD](https://openscad.org) - Script-based 3D CAD modeler for creating precise solid geometry. 🪟 🍎 🐧
 - [Wings 3D](https://www.wings3d.com) - 3D modeling software focusing on subdivision modeling. 🪟 🍎 🐧 🟢
 
+[Move to top](#contents)
+
 ## Security
+
+[Move to top](#contents)
 
 ### Antivirus
 
 - [Avast](https://avast.com/free-antivirus-download) - Antivirus to help detect and isolate potential cyberthreats. 🪟 🍎 🐧
 - [ClamAV](https://www.clamav.net) - Antivirus engine for detecting malware, viruses, and other threats. 🪟 🍎 🐧 🟢
 - [Pareto Security](https://paretosecurity.com/apps) - Check for basic security hygiene of any Windows, Mac or Linux desktop. 🪟 🍎 🐧 [🟢](https://github.com/paretoSecurity/agent)
+
+[Move to top](#contents)
 
 ### Password Managers
 
@@ -416,13 +492,19 @@
 - [RoboForm](https://roboform.com) - Password manager and form filler with multi-platform synchronization. 🪟 🍎 🐧
 - [ProtonPass](https://proton.me/pass) - Free password manager with end-to-end encryption based in Switzerland. 🪟 🍎 🐧 [🟢](https://github.com/protonpass)
 
+[Move to top](#contents)
+
 ### Ad & Tracker Blocking
 
+
+[Move to top](#contents)
 
 ## Image Viewers
 
 - [qView](https://interversehq.com/qview) - Visually minimal and space efficient. 🪟 🍎 🐧
 - [XnView](https://xnview.com/en) - Image resizer, batch image converter. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ## Remote Access
 
@@ -436,9 +518,13 @@
 - [Remmina](https://remmina.org) - Remote access screen and file sharing to your desktop. 🐧
 - [RemSupp](https://remsupp.com) - Simple remote desktop. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ## Video
 
 - [FreeTube](https://freetubeapp.io) - Private YouTube client with no ads. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ### Video Editors
 
@@ -451,6 +537,8 @@
 - [Avidemux](https://avidemux.sourceforge.net) - Video editor designed for simple cutting, filtering and encoding tasks. 🪟 🍎 🐧 [🟢](https://github.com/mean00/avidemux2)
 - [lossless-cut](https://losslesscut.app) - Swiss army knife of lossless video/audio editing. 🪟 🍎 🐧 [🟢](https://github.com/mifi/lossless-cut)
 
+[Move to top](#contents)
+
 ### Video Players
 
 - [Bomi Player](https://bomi-player.github.io) - Advanced media player that supports a variety of video formats. 🐧
@@ -460,6 +548,8 @@
 - [Stremio](https://stremio.com) - Provides a secure, modern and seamless entertainment experience. 🪟 🍎 🐧
 - [SMPlayer](https://sourceforge.net/projects/smplayer) - Media player with the ability to remember playback settings and support for various video formats. 🪟 🍎 🐧
 - [VLC Media Player](https://videolan.org/vlc) - Media player supporting almost all video formats. 🪟 🍎 🐧 🟢
+
+[Move to top](#contents)
 
 ### Video Streaming and Recording
 
@@ -471,10 +561,14 @@
 - [Zoom](https://zoom.us) - Video meetings with streaming, recording, and screen sharing. 🪟 🍎 🐧
 - [GPU Screen Recorder](https://flathub.org/apps/com.dec05eba.gpu_screen_recorder) - Shadowplay-like screen recorder that is fast. 🐧
 
+[Move to top](#contents)
+
 ### Video Converters and Compressors
 
 - [FFmpeg](https://ffmpeg.org) - Powerful tool for format conversion and multimedia editing. 🪟 🍎 🐧 🟢 ⭐
 - [HandBrake](https://handbrake.fr) - Video transcoder with preset profiles for device compatibility. 🪟 🍎 🐧 🟢
+
+[Move to top](#contents)
 
 ## VPN and Proxy Tools
 
@@ -489,6 +583,8 @@
 - [WireGuard](https://wireguard.com) - Fast, secure VPN protocol designed for simplicity. 🪟 🍎 🐧 [🟢](https://www.wireguard.com/repositories)
 - [Tailscale](https://tailscale.com) - Mesh VPN client for secure private networks using WireGuard. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ## Utility
 
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp) - Command-line tool for downloading audio and video. 🪟 🍎 🐧 [🟢](https://github.com/yt-dlp/yt-dlp) ⭐
@@ -498,6 +594,8 @@
 - [Windterm](https://github.com/kingToolbox/WindTerm) - SSH/Telnet/Serial/Shell/Sftp client for DevOps.  🪟 🍎 🐧 🟢
 - [balenaEtcher](https://etcher.balena.io) - Tool for safely flashing OS images to SD cards and USB drives. 🪟 🍎 🐧 [🟢](https://github.com/balena-io/etcher)
 
+[Move to top](#contents)
+
 ### Clipboard Management
 
 - [CopyQ](https://hluk.github.io/CopyQ) - Clipboard manager with editing and scripting features. 🪟 🍎 🐧 🟢
@@ -506,10 +604,14 @@
 - [Parcellite](https://parcellite.sourceforge.io) - Basic clipboard manager. 🐧
 - [Qopy](https://github.com/0pandadev/qopy) - Minimalist clipboard manager with unique features. 🪟 🍎 🐧 🟢
 
+[Move to top](#contents)
+
 ### Metadata
 
 - [ExifTool](https://exiftool.org) - Command-line tool for editing metadata in various file types. 🪟 🍎 🐧 ⭐
 
+
+[Move to top](#contents)
 
 ### Window Management
 
@@ -519,14 +621,20 @@
 - [XMonad](https://xmonad.org) - Customizable tiling window manager. 🐧
 - [Niri](https://github.com/niri-wm/niri) - Scrollable-tiling Wayland compositor written in Rust. 🐧 🟢
 
+[Move to top](#contents)
+
 ### File Management
 
 - [Double Commander](https://doublecmd.sourceforge.io) - Dual-pane manager with built-in editor and advanced search. 🪟 🍎 🐧
 - [FileZilla](https://filezilla-project.org) - Reliable FTP, FTPS, and SFTP client for remote management. 🪟 🍎 🐧
 - [Sigma File Manager](https://github.com/aleksey-hoffman/sigma-file-manager) - Modern file manager with advanced features. 🪟 🐧 [🟢](https://github.com/aleksey-hoffman/sigma-file-manager)
 
+[Move to top](#contents)
+
 ### Application Management
 
+
+[Move to top](#contents)
 
 ### Screenshot
 
@@ -534,10 +642,14 @@
 - [Shutter](https://launchpad.net/shutter) - Feature-rich screenshot tool for Linux with an integrated editor for quick annotations. 🐧
 - [Snipaste](https://snipaste.com) - Free, Customizable, Portable snipping tool.
 
+[Move to top](#contents)
+
 ### Space Visualizer
 
 - [Filelight](https://kde.org/applications/utilities/org.kde.filelight) - Visualizer with a circular sunburst chart. 🪟 🍎 🐧
 - [JDiskReport](https://www.jgoodies.com/freeware/jdiskreport) - Tool for visualizing disk usage with a variety of charts and graphs. 🪟 🐧
+
+[Move to top](#contents)
 
 ### Trackpad
 

--- a/filter/macOS-only.md
+++ b/filter/macOS-only.md
@@ -88,15 +88,21 @@
 - [JACK Audio](https://jackaudio.org) - Audio server for routing and mixing sound between programs. 🪟 🍎 🐧
 - [BlackHole](https://github.com/ExistentialAudio/BlackHole) - Virtual audio loopback driver for routing audio between macOS applications. 🍎 🟢
 
+[Move to top](#contents)
+
 ### Audio Players
 
 - [Foobar2000](https://foobar2000.org) - Lightweight and highly customizable audio player with support for many formats. 🪟 🍎 ⭐
 - [Strawberry Music Player](https://strawberrymusicplayer.org) - Music player for organizing and playing your audio collection. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ### Audio Recording
 
 - [Audacity](https://audacityteam.org/download) - Audio editor for recording and editing sounds. 🪟 🍎 🐧 🟢 ⭐
 - [Ocenaudio](https://ocenaudio.com) - Easy-to-use audio editor for recording and analyzing sounds. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ### DJ Software
 
@@ -104,6 +110,8 @@
 - [Serato DJ Lite](https://serato.com/dj/lite) - DJ software for beginners to mix music with ease. 🪟 🍎
 - [Rekordbox](https://rekordbox.com/en) - Software that enables a comfortable DJ workflow with AI, cloud, and automation tech. 🪟 🍎
 - [VirtualDJ](https://virtualdj.com) - DJ platform for mixing music, beatmatching, and live performance. 🪟 🍎
+
+[Move to top](#contents)
 
 ### Music Notation
 
@@ -113,6 +121,8 @@
 - [LilyPond](https://lilypond.org) - Music notation program for creating high-quality sheet music. 🪟 🍎 🐧
 - [MuseScore](https://musescore.org) - Software for creating, playing, and sharing sheet music. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ### Music Production
 
 - [LMMS](https://lmms.io) - DAW for creating music with virtual instruments and MIDI support. 🪟 🍎 🐧 🟢 ⭐
@@ -121,6 +131,8 @@
 - [MilkyTracker](https://github.com/milkytracker/MilkyTracker) - Cross platform XM tracker. 🪟 🍎 🐧 🟢
 - [Stargate DAW](https://github.com/stargatedaw/stargate) - Innovation-first DAW, instrument and effect plugins. 🪟 🍎 🐧 🟢
 - [Tracktion T7](https://tracktion.com/products/t7-daw) - DAW for music production with advanced editing features. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ## Browsers
 
@@ -144,7 +156,11 @@
 - [Vivaldi](https://vivaldi.com) - Customizable browser putting you in control. 🪟 🍎 🐧
 - [Zen Browser](https://zen-browser.app) - Beautifully designed, privacy-focused browser with custom mods. 🪟 🍎 🐧 [🟢](https://github.com/zen-browser/desktop)
 
+[Move to top](#contents)
+
 ## Communication
+
+[Move to top](#contents)
 
 ### Messaging
 
@@ -156,6 +172,8 @@
 - [Viber](https://viber.com) - Free messaging app with text, voice, video calls, and file sharing. 🪟 🍎 🐧
 - [Microsoft Teams](https://microsoft.com/en-us/microsoft-teams/group-chat-software) - Team communication platform with chat, file sharing, and video conferencing. 🪟 🍎 🐧
 - [Skype](https://skype.com) - Messaging and video call service supporting text, voice, and video. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ### Email Clients
 
@@ -173,6 +191,8 @@
 - [ThunderBird](https://thunderbird.net) - Email client for easier management. 🪟 🍎 🐧 🟢
 - [Tutanota](https://tutanota.com) - Encrypted service focused on privacy. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ## Compression and Archiving
 
 - [muCommander](https://www.mucommander.com) - Lightweight dual-pane file manager with archive support. 🍎
@@ -181,7 +201,11 @@
 - [Unarchive One](https://cleanerone.trendmicro.com/unarchiver-one/?utm_source=github&utm_medium=referral&utm_campaign=githubproject) - Multi-format decompression tool with QuickLook integration. 🍎
 - [Keka](https://www.keka.io) - File archiver for compressing and extracting common archive formats. 🍎
 
+[Move to top](#contents)
+
 ## Customize
+
+[Move to top](#contents)
 
 ### System Customization
 
@@ -192,22 +216,32 @@
 - [SaneClick](https://saneclick.com) - Finder toolbar customizer for adding quick actions. 🍎 [🟢](https://github.com/sane-apps/SaneClick)
 - [Thaw](https://github.com/stonerl/Thaw) - Menu bar manager for hiding, arranging, and customizing menu bar items. 🍎 [🟢](https://github.com/stonerl/Thaw)
 
+[Move to top](#contents)
+
 ### Wallpaper Tools
 
 - [Plash](https://sindresorhus.com/plash) - App to set websites as wallpapers. 🍎 🟢
 
+[Move to top](#contents)
+
 ## Data Management
+
+[Move to top](#contents)
 
 ### Copy and Move
 
 - [TeraCopy](https://codesector.com/teracopy) - Copy and move multiple files. 🪟 🍎
 - [Blip](https://blip.net) - Direct file transfer app with unlimited file sizes, folder support, and transfer resume. 🪟 🍎 ⭐
 
+[Move to top](#contents)
+
 ### Sync and Clone
 
 - [FreeFileSync](https://freefilesync.org) - Tool for comparing and syncing files or folders. 🪟 🍎 🐧 🟢 ⭐
 - [rclone](https://rclone.org) - Command-line tool for managing and syncing files with cloud storage. 🪟 🍎 🐧
 - [Syncthing](https://github.com/syncthing/syncthing) - Continuous file synchronization for multiple computers. 🪟 🍎 🐧 🟢
+
+[Move to top](#contents)
 
 ## Developer Tools
 
@@ -219,6 +253,8 @@
 - [Android Studio](https://developer.android.com/studio) - Official IDE for Android development with emulator, code editor, and build tools. 🪟 🍎 🐧
 - [GitHub Desktop](https://desktop.github.com) - Graphical Git client for cloning repositories, reviewing changes, and syncing with GitHub. 🪟 🍎 [🟢](https://github.com/desktop/desktop)
 - [WezTerm](https://wezterm.org) - GPU-accelerated terminal emulator and multiplexer with tabs, panes, SSH, and Lua configuration. 🪟 🍎 🐧 [🟢](https://github.com/wezterm/wezterm)
+
+[Move to top](#contents)
 
 ### API Development
 
@@ -237,11 +273,15 @@
 - [Yaak](https://yaak.app) - An offline and Git friendly API tester for HTTP, GraphQL, WebSockets, SSE, and gRPC. 🪟 🍎 🐧 [🟢](https://github.com/mountain-loop/yaak)
 - [Endpoint](https://apps.apple.com/tr/app/endpoint-http-client/id6755891816?mt=12) - Native macOS API client with WebSocket support, performance testing, and customizable themes. 🍎
 
+[Move to top](#contents)
+
 ### Database
 
 - [DBeaver](https://dbeaver.io) - Universal database tool for SQL databases like MySQL, MariaDB, PostgreSQL, SQLite, Apache Family, and more. 🪟 🍎 🐧 ⭐
 - [Beekeeper Studio](https://beekeeperstudio.io) - Modern, lightweight SQL client supporting MySQL, Postgres, SQLite, SQL Server, etc. 🪟 🍎 🐧
 - [DB Browser for SQLite](https://sqlitebrowser.org) - Visual tool for creating, browsing, and editing SQLite database files. 🪟 🍎 🐧 [🟢](https://github.com/sqlitebrowser/sqlitebrowser)
+
+[Move to top](#contents)
 
 ### Network Analysis
 
@@ -253,6 +293,8 @@
 - [Proxie](https://proxie.app) - HTTP debugging proxy for tracking requests. 🍎
 - [Proxyman](https://proxyman.io) - Modern HTTP proxy with an intuitive UI. 🍎
 - [Sniffnet](https://sniffnet.net) - Tool for monitoring and analyzing network traffic. 🪟 🍎 🐧 [🟢](https://github.com/GyulyVGC/sniffnet)
+
+[Move to top](#contents)
 
 ### Game Engines
 
@@ -276,6 +318,8 @@
 - [Tiled](https://mapeditor.org) - Level editor for creating tile-based game maps, used with other engines. 🪟 🍎 🐧 🟢
 - [Unity](https://unity.com) - Popular game engine for creating both 2D and 3D games, with an intuitive interface and wide asset store. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ### Virtualization
 
 - [Docker](https://docker.com) - Containerization platform for operating-system-level virtualization. 🪟 🍎 🐧 🟢 ⭐
@@ -291,8 +335,12 @@
 - [VMWare Workstation](https://vmware.com/products/desktop-hypervisor/workstation-and-fusion) - Virtualization software with advanced features. 🪟 🍎 🐧
 - [Mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS built on Apple's Containerization framework. 🍎 [🟢](https://github.com/us/mocker)
 
+[Move to top](#contents)
+
 ## Documents
 
+
+[Move to top](#contents)
 
 ### Office Suites
 
@@ -306,6 +354,8 @@
 - [OnlyOffice](https://onlyoffice.com) - Office suite with collaboration features. 🪟 🍎 🐧 🟢
 - [WPS Office](https://wps.com) - Lightweight office suite compatible with MS file formats. 🪟 🍎 🐧
 
+
+[Move to top](#contents)
 
 ### E-book
 
@@ -321,6 +371,8 @@
 - [Sigil](https://sigil-ebook.com) - EPUB editor. 🪟 🍎 🐧 [🟢](https://github.com/Sigil-Ebook/Sigil)
 - [Simple Comic](https://apps.apple.com/us/app/simple-comic/id1497435571?mt=12) - Reader for PDF, CBZ, and CBR formats. 🍎
 
+[Move to top](#contents)
+
 ### PDF Tools
 
 - [Foxit PDF Reader](https://foxit.com/pdf-reader) - PDF viewer with annotations. 🪟 🍎
@@ -329,6 +381,8 @@
 - [Xournal++](https://xournalpp.github.io) - Handwriting and annotation tool for PDFs. 🪟 🍎 🐧 [🟢](https://github.com/xournalpp/xournalpp)
 - [PDFGear](https://www.pdfgear.com) - Read, edit, convert, merge, and sign PDF files across devices. 🪟 🍎
 - [PDFsam](https://pdfsam.org) - Extract pages, split, merge, mix and rotate PDF files. 🪟 🍎 🐧 [🟢](https://github.com/torakiki/pdfsam)
+
+[Move to top](#contents)
 
 ## Note Taking
 
@@ -342,6 +396,8 @@
 - [RemNote](https://remnote.io) - Knowledge management app with note-taking and spaced repetition features. 🪟 🍎 🐧
 - [Simplenote](https://simplenote.com) - Minimalist note-taking app that syncs across devices. 🪟 🍎 🐧 [🟢](https://github.com/Automattic/simplenote-electron)
 - [fylepad](https://fylepad.vercel.app) - Lightweight notepad with powerful rich-text editing. 🪟 🍎 🐧 [🟢](https://github.com/imrofayel/fylepad)
+
+[Move to top](#contents)
 
 ## Text Editors
 
@@ -370,6 +426,8 @@
 - [VSCodium](https://vscodium.com) - Community-built VS Code binaries without Microsoft branding, telemetry, or licensing changes. 🪟 🍎 🐧 [🟢](https://github.com/VSCodium/vscodium)
 - [MarkEdit](https://github.com/MarkEdit-app/MarkEdit) - Native Markdown editor for macOS with a TextEdit-like workflow and local-file editing. 🍎 🟢
 
+[Move to top](#contents)
+
 ## Download Managers
 
 - [Free Download Manager](https://freedownloadmanager.org) - Modern download accelerator. 🪟 🍎 🐧 ⭐
@@ -379,6 +437,8 @@
 - [Persepolis Download Manager](https://persepolisdm.github.io) - GUI for Aria2, providing an intuitive interface. 🪟 🍎 🐧 [🟢](https://github.com/persepolisdm/persepolis)
 - [Xtreme Download Manager (XDM)](https://xtremedownloadmanager.com) - Powerful tool to increase download speed. 🪟 🍎 🐧 [🟢](https://github.com/subhra74/xdm)
 - [Transmission](https://transmissionbt.com) - Lightweight BitTorrent client with native desktop, daemon, and web interfaces. 🪟 🍎 🐧 [🟢](https://github.com/transmission/transmission)
+
+[Move to top](#contents)
 
 ## Games
 
@@ -393,6 +453,8 @@
 - [Porting Kit](https://portingkit.com) - Install Windows games on Mac. 🍎
 - [Ubisoft Connect](https://ubisoftconnect.com) - Game launcher for Ubisoft titles. 🪟 🍎
 
+[Move to top](#contents)
+
 ### Cloud Gaming
 
 - [Antstream Arcade](https://www.antstream.com) - Free tier with retro games playable via the cloud. 🪟 🍎 🐧
@@ -400,12 +462,16 @@
 - [NVIDIA GeForce NOW](https://www.nvidia.com/en-us/geforce-now) - Free tier for streaming supported games from the cloud. 🪟 🍎 🐧
 - [Xbox Cloud Gaming](https://www.xbox.com/en-US/play) - Free trial with limited titles via the cloud. 🪟 🍎
 
+[Move to top](#contents)
+
 ## Mobile Emulators
 
 - [BlueStacks](https://www.bluestacks.com) - Android emulator for playing mobile games on PC. 🪟 🍎 ⭐
 - [Andy](https://www.andyroid.net) - Android emulator to run mobile games and apps on PC. 🪟 🍎
 - [Genymotion](https://genymotion.com) - Android emulator with advanced features for developers and gamers. 🪟 🍎 🐧
 - [NoxPlayer](https://bignox.com) - Android emulator optimized for mobile gaming on desktop. 🪟 🍎
+
+[Move to top](#contents)
 
 ## Other Emulators
 
@@ -423,6 +489,8 @@
 - [xemu](https://xemu.app) - Original Xbox emulator for playing classic Xbox games on modern systems. 🪟 🍎 🐧
 - [MelonDS](https://melonds.kuribo64.net) - Nintendo DS emulator with accurate performance and Wi-Fi support. 🪟 🍎 🐧
 - [BSNES](https://bsnes.dev) - SNES emulator with cycle-accurate emulation for high compatibility. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ## Graphics Tools
 
@@ -446,6 +514,8 @@
 - [Pixen](https://pixenapp.com/mac) - Native pixel art and animation editor designed. 🍎
 - [Affinity](https://www.affinity.studio/) - Professional creative suite for photo editing, graphic design, and desktop publishing. 🪟 🍎
 
+[Move to top](#contents)
+
 ## 3D Modeling and Animation
 
 - [Blender](https://blender.org) - 3D creation tool supporting modeling, animation, rendering, video editing, and more. 🪟 🍎 🐧 🟢 ⭐
@@ -454,7 +524,11 @@
 - [OpenSCAD](https://openscad.org) - Script-based 3D CAD modeler for creating precise solid geometry. 🪟 🍎 🐧
 - [Wings 3D](https://www.wings3d.com) - 3D modeling software focusing on subdivision modeling. 🪟 🍎 🐧 🟢
 
+[Move to top](#contents)
+
 ## Security
+
+[Move to top](#contents)
 
 ### Antivirus
 
@@ -464,6 +538,8 @@
 - [ClamAV](https://www.clamav.net) - Antivirus engine for detecting malware, viruses, and other threats. 🪟 🍎 🐧 🟢
 - [Malwarebytes](https://malwarebytes.com) - Malware removal tool offering real-time protection and cleanup. 🪟 🍎
 - [Pareto Security](https://paretosecurity.com/apps) - Check for basic security hygiene of any Windows, Mac or Linux desktop. 🪟 🍎 🐧 [🟢](https://github.com/paretoSecurity/agent)
+
+[Move to top](#contents)
 
 ### Password Managers
 
@@ -476,15 +552,21 @@
 - [RoboForm](https://roboform.com) - Password manager and form filler with multi-platform synchronization. 🪟 🍎 🐧
 - [ProtonPass](https://proton.me/pass) - Free password manager with end-to-end encryption based in Switzerland. 🪟 🍎 🐧 [🟢](https://github.com/protonpass)
 
+[Move to top](#contents)
+
 ### Ad & Tracker Blocking
 
 - [SaneHosts](https://sanehosts.com) - macOS hosts file manager for system-wide ad and tracker blocking. 🍎 [🟢](https://github.com/sane-apps/SaneHosts)
+
+[Move to top](#contents)
 
 ## Image Viewers
 
 - [FlowVision](https://github.com/netdcy/FlowVision) - Waterfall-style image viewer. 🍎 🟢
 - [qView](https://interversehq.com/qview) - Visually minimal and space efficient. 🪟 🍎 🐧
 - [XnView](https://xnview.com/en) - Image resizer, batch image converter. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ## Remote Access
 
@@ -498,9 +580,13 @@
 - [TeamViewer](https://teamviewer.com/en) - Popular remote control software for desktop sharing and file transfer. 🪟 🍎 🐧
 - [RemSupp](https://remsupp.com) - Simple remote desktop. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ## Video
 
 - [FreeTube](https://freetubeapp.io) - Private YouTube client with no ads. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ### Video Editors
 
@@ -513,6 +599,8 @@
 - [Olive Video Editor](https://olivevideoeditor.org) - Non-linear video editor with powerful features and an intuitive interface. 🪟 🍎 🐧 [🟢](https://github.com/olive-editor/olive)
 - [Avidemux](https://avidemux.sourceforge.net) - Video editor designed for simple cutting, filtering and encoding tasks. 🪟 🍎 🐧 [🟢](https://github.com/mean00/avidemux2)
 - [lossless-cut](https://losslesscut.app) - Swiss army knife of lossless video/audio editing. 🪟 🍎 🐧 [🟢](https://github.com/mifi/lossless-cut)
+
+[Move to top](#contents)
 
 ### Video Players
 
@@ -527,6 +615,8 @@
 - [SMPlayer](https://sourceforge.net/projects/smplayer) - Media player with the ability to remember playback settings and support for various video formats. 🪟 🍎 🐧
 - [VLC Media Player](https://videolan.org/vlc) - Media player supporting almost all video formats. 🪟 🍎 🐧 🟢
 
+[Move to top](#contents)
+
 ### Video Streaming and Recording
 
 - [OBS Studio](https://obsproject.com) - Software for live streaming and recording video. 🪟 🍎 🐧 🟢 ⭐
@@ -536,6 +626,8 @@
 - [Streamlabs Desktop](https://streamlabs.com) - Streaming software with customizable alerts and overlays. 🪟 🍎 🟢
 - [Zoom](https://zoom.us) - Video meetings with streaming, recording, and screen sharing. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ### Video Converters and Compressors
 
 - [FFmpeg](https://ffmpeg.org) - Powerful tool for format conversion and multimedia editing. 🪟 🍎 🐧 🟢 ⭐
@@ -544,6 +636,8 @@
 - [Shutter Encoder](https://shutterencoder.com) - Supports video, audio, and image conversion with extra processing tools. 🪟 🍎
 - [VidCoder](https://vidcoder.net) - User-friendly HandBrake-based transcoder with batch processing. 🪟 🍎 🟢
 - [Adapter](https://macroplant.com/adapter/video-converter) - Media converter app for video, audio, and images on Mac and Windows. 🪟 🍎
+
+[Move to top](#contents)
 
 ## VPN and Proxy Tools
 
@@ -564,6 +658,8 @@
 - [WireGuard](https://wireguard.com) - Fast, secure VPN protocol designed for simplicity. 🪟 🍎 🐧 [🟢](https://www.wireguard.com/repositories)
 - [Tailscale](https://tailscale.com) - Mesh VPN client for secure private networks using WireGuard. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ## Utility
 
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp) - Command-line tool for downloading audio and video. 🪟 🍎 🐧 [🟢](https://github.com/yt-dlp/yt-dlp) ⭐
@@ -582,6 +678,8 @@
 - [MonitorControl](https://monitorcontrol.app) - Controls external display brightness, volume, and contrast from macOS keyboard shortcuts and menu bar. 🍎 [🟢](https://github.com/MonitorControl/MonitorControl)
 - [balenaEtcher](https://etcher.balena.io) - Tool for safely flashing OS images to SD cards and USB drives. 🪟 🍎 🐧 [🟢](https://github.com/balena-io/etcher)
 
+[Move to top](#contents)
+
 ### Clipboard Management
 
 - [Clipboard Fusion](https://clipboardfusion.com) - Clipboard manager with data transformation features. 🪟 🍎
@@ -592,10 +690,14 @@
 - [Qopy](https://github.com/0pandadev/qopy) - Minimalist clipboard manager with unique features. 🪟 🍎 🐧 🟢
 - [SaneClip](https://saneclip.com) - Clipboard manager that keeps all history local with search and formatting tools. 🍎 [🟢](https://github.com/sane-apps/SaneClip)
 
+[Move to top](#contents)
+
 ### Metadata
 
 - [ExifTool](https://exiftool.org) - Command-line tool for editing metadata in various file types. 🪟 🍎 🐧 ⭐
 
+
+[Move to top](#contents)
 
 ### Window Management
 
@@ -603,15 +705,21 @@
 - [Magnet](https://apps.apple.com/us/app/magnet/id441258766?mt=12) - Snap windows into organized tiles. 🍎
 - [AltTab](https://alt-tab.app) - Window switcher that brings Windows-style alt-tab previews and controls to macOS. 🍎 [🟢](https://github.com/lwouis/alt-tab-macos)
 
+[Move to top](#contents)
+
 ### File Management
 
 - [Double Commander](https://doublecmd.sourceforge.io) - Dual-pane manager with built-in editor and advanced search. 🪟 🍎 🐧
 - [FileZilla](https://filezilla-project.org) - Reliable FTP, FTPS, and SFTP client for remote management. 🪟 🍎 🐧
 - [Cyberduck](https://cyberduck.io) - File transfer client for FTP, SFTP, WebDAV, S3, Azure, OneDrive, and other storage services. 🪟 🍎 [🟢](https://github.com/iterate-ch/cyberduck)
 
+[Move to top](#contents)
+
 ### Application Management
 
 - [PureMac](https://github.com/momenbasel/PureMac) - macOS app manager and system cleaner for uninstalling apps, removing orphaned files, and cleaning caches. 🍎 🟢
+
+[Move to top](#contents)
 
 ### Screenshot
 
@@ -621,10 +729,14 @@
 - [Monosnap](https://monosnap.com) - Simple screenshot tool that includes cloud integration for easy sharing. 🪟 🍎
 - [Snipaste](https://snipaste.com) - Free, Customizable, Portable snipping tool.
 
+[Move to top](#contents)
+
 ### Space Visualizer
 
 - [ClearDisk](https://github.com/bysiber/cleardisk) - macOS menu bar app to visualize and clean developer caches (Xcode, node_modules, CocoaPods, Docker, pip, Cargo). 🍎 [🟢](https://github.com/bysiber/cleardisk)
 - [Filelight](https://kde.org/applications/utilities/org.kde.filelight) - Visualizer with a circular sunburst chart. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ### Trackpad
 

--- a/filter/open-source-mobile-only.md
+++ b/filter/open-source-mobile-only.md
@@ -79,71 +79,113 @@
 
 ## Audio
 
+[Move to top](#contents)
+
 ### Audio Players
 
+
+[Move to top](#contents)
 
 ### Audio Recording
 
 
+[Move to top](#contents)
+
 ### DJ Software
 
+
+[Move to top](#contents)
 
 ### Music Notation
 
 - [MuseScore](https://musescore.com) - Open-source notation app for composing and sharing sheet music. 🤖 🍎 🟢
 
+[Move to top](#contents)
+
 ### Music Production
 
 
+
+[Move to top](#contents)
 
 ## Browsers
 
 - [Firefox](https://www.mozilla.org/firefox) - Privacy-focused browser with customizable extensions and tracking protection. 🤖 🍎 🟢
 
+[Move to top](#contents)
+
 ## Communication
+
+[Move to top](#contents)
 
 ### Messaging
 
 - [Signal](https://signal.org) - Encrypted messaging app with privacy-first design. 🤖 🍎 🟢
 - [Element](https://element.io) - Secure messaging with Matrix protocol and decentralized features. 🤖 🍎 🟢
 
+[Move to top](#contents)
+
 ### Email Clients
 
 - [Proton Mail](https://proton.me/mail) - Encrypted email with no ads and advanced privacy tools. 🤖 🍎 🟢
 - [FairEmail](https://email.faircode.eu) - Lightweight open-source email client with strong privacy features. 🤖 🟢
 
+[Move to top](#contents)
+
 ## Compression and Archiving
 
 
+[Move to top](#contents)
+
 ## Customize
+
+[Move to top](#contents)
 
 ### System Customization
 
+
+[Move to top](#contents)
 
 ### Wallpaper Tools
 
 - [Resplash](https://unsplash.com) - Access Unsplash’s library for stunning, free wallpapers. 🤖 🍎 🟢
 
+[Move to top](#contents)
+
 ## Data Management
+
+[Move to top](#contents)
 
 ### Copy and Move
 
 
+[Move to top](#contents)
+
 ### Sync and Clone
 
+
+[Move to top](#contents)
 
 ## Developer Tools
 
 - [Termux](https://termux.dev) - Terminal emulator with Linux packages for development. 🤖 🟢
 
+[Move to top](#contents)
+
 ### API Development
 
+
+[Move to top](#contents)
 
 ### Database
 
 
+[Move to top](#contents)
+
 ### Network Analysis
 
+
+[Move to top](#contents)
 
 ### Game Engines
 
@@ -151,21 +193,33 @@
 - [Pocket Code](https://www.catrobat.org) - Build simple games and apps using visual programming. 🤖 🍎 🟢
 - [GDevelop](https://gdevelop.io) - Open-source game engine to create games without coding. 🤖 🟢
 
+[Move to top](#contents)
+
 ### Virtualization
 
 - [Linux Deploy](https://github.com/meefik/linuxdeploy) - Install and run Linux distributions on your mobile device. 🤖 🟢
 - [UTM](https://github.com/utmapp/UTM) - Load virtual machines on your iPhone or iPad. 🍎 🟢
 
+[Move to top](#contents)
+
 ## Documents
+
+[Move to top](#contents)
 
 ### Office Suites
 
 
+[Move to top](#contents)
+
 ### E-book
 
 
+[Move to top](#contents)
+
 ### PDF Tools
 
+
+[Move to top](#contents)
 
 ## Note Taking
 
@@ -173,79 +227,129 @@
 - [Notely Voice](https://github.com/tosinonikute/NotelyVoice) - 100% private notes and free AI voice-to-text transcription. [🟢](https://github.com/tosinonikute/NotelyVoice)
 - [DailyVox](https://getdailyvox.com) - Free AI voice diary with on-device transcription, mood tracking, and Digital Twin. No cloud, no accounts. 🍎 [🟢](https://github.com/intrepidkarthi/dailyvox)
 
+[Move to top](#contents)
+
 ## Text Editors
 
+
+[Move to top](#contents)
 
 ## Finance
 
 
+[Move to top](#contents)
+
 ## Download Managers
 
+
+[Move to top](#contents)
 
 ## Graphics Tools
 
 
+[Move to top](#contents)
+
 ## 3D Modeling and Animation
 
 
+[Move to top](#contents)
+
 ## Security
+
+[Move to top](#contents)
 
 ### Antivirus
 
+
+[Move to top](#contents)
 
 ### Password Managers
 
 - [Bitwarden](https://bitwarden.com) - Open-source password manager with end-to-end encryption. 🤖 🍎 🟢
 
+[Move to top](#contents)
+
 ## Image Viewers
 
 - [Simple Gallery](https://simplemobiletools.com/gallery) - Lightweight image viewer with sorting and editing options. 🤖 🟢
 
+[Move to top](#contents)
+
 ## Remote Access
 
 
+[Move to top](#contents)
+
 ## Video
+
+[Move to top](#contents)
 
 ### Video Editors
 
 
+[Move to top](#contents)
+
 ### Video Players
 
+
+[Move to top](#contents)
 
 ### Video Streaming and Recording
 
 
+[Move to top](#contents)
+
 ### Video Converters and Compressors
 
+
+[Move to top](#contents)
 
 ## VPN and Proxy Tools
 
 - [ProtonVPN](https://protonvpn.com) - Secure, encrypted VPN with no logs policy and high-speed servers. 🤖 🍎 🟢
 - [Windscribe](https://windscribe.com) - Privacy-focused VPN with a free option and wide server coverage. 🤖 🍎 🟢
 
+[Move to top](#contents)
+
 ## Health and Wellness
 
 - [Euki](https://eukiapp.org) - Privacy-first period tracker with sexual health resources and local-only data storage. 🤖 🍎 [🟢](https://github.com/Euki-Inc/Euki-Android)
 
+[Move to top](#contents)
+
 ## Utility
+
+[Move to top](#contents)
 
 ### Clipboard Management
 
 
+[Move to top](#contents)
+
 ### Metadata
 
+
+[Move to top](#contents)
 
 ### Window Management
 
 
+[Move to top](#contents)
+
 ### File Management
 
+
+[Move to top](#contents)
 
 ### Application Management
 
 
+[Move to top](#contents)
+
 ### Screenshot
 
+
+[Move to top](#contents)
 
 ### Space Visualizer
 

--- a/filter/open-source-only.md
+++ b/filter/open-source-only.md
@@ -89,19 +89,29 @@
 - [Ambie](https://github.com/jenius-apps/ambie) - Use white noise, nature sounds, & more to boost your productivity. 🪟 🟢
 - [BlackHole](https://github.com/ExistentialAudio/BlackHole) - Virtual audio loopback driver for routing audio between macOS applications. 🍎 🟢
 
+[Move to top](#contents)
+
 ### Audio Players
 
 - [Audacious](https://github.com/audacious-media-player/audacious) - Lightweight audio player for simple music playback. 🪟 🐧 🟢
+
+[Move to top](#contents)
 
 ### Audio Recording
 
 - [Audacity](https://audacityteam.org/download) - Audio editor for recording and editing sounds. 🪟 🍎 🐧 🟢 ⭐
 
+[Move to top](#contents)
+
 ### DJ Software
 
 
+[Move to top](#contents)
+
 ### Music Notation
 
+
+[Move to top](#contents)
 
 ### Music Production
 
@@ -109,6 +119,8 @@
 - [Furnace](https://github.com/tildearrow/furnace) - Multi-system chiptune tracker. 🪟 🍎 🐧 🟢
 - [MilkyTracker](https://github.com/milkytracker/MilkyTracker) - Cross platform XM tracker. 🪟 🍎 🐧 🟢
 - [Stargate DAW](https://github.com/stargatedaw/stargate) - Innovation-first DAW, instrument and effect plugins. 🪟 🍎 🐧 🟢
+
+[Move to top](#contents)
 
 ## Browsers
 
@@ -123,10 +135,16 @@
 - [Mullvad Browser](https://mullvad.net/en/download/browser) - Privacy browser with Tor, anti-fingerprinting, and Mullvad VPN. 🪟 🍎 🐧 [🟢](https://github.com/mullvad/mullvad-browser)
 - [Zen Browser](https://zen-browser.app) - Beautifully designed, privacy-focused browser with custom mods. 🪟 🍎 🐧 [🟢](https://github.com/zen-browser/desktop)
 
+[Move to top](#contents)
+
 ## Communication
+
+[Move to top](#contents)
 
 ### Messaging
 
+
+[Move to top](#contents)
 
 ### Email Clients
 
@@ -135,13 +153,19 @@
 - [Mailspring](https://getmailspring.com) - Beautiful, fast email client. 🪟 🍎 🐧 🟢
 - [ThunderBird](https://thunderbird.net) - Email client for easier management. 🪟 🍎 🐧 🟢
 
+[Move to top](#contents)
+
 ## Compression and Archiving
 
 - [7-Zip](https://7-zip.org/download.html) - Archive manager supporting 7z, ZIP, and other formats. 🪟 🟢 ⭐
 - [PDF Archiver](https://github.com/JulianKahnert/PDF-Archiver) - Tool for tagging and organizing PDFs. 🍎 🟢
 - [PeaZip](https://peazip.github.io) - Archive manager supporting 180+ formats with encryption and compression. 🪟 🐧 🟢
 
+[Move to top](#contents)
+
 ## Customize
+
+[Move to top](#contents)
 
 ### System Customization
 
@@ -158,6 +182,8 @@
 - [SaneClick](https://saneclick.com) - Finder toolbar customizer for adding quick actions. 🍎 [🟢](https://github.com/sane-apps/SaneClick)
 - [Thaw](https://github.com/stonerl/Thaw) - Menu bar manager for hiding, arranging, and customizing menu bar items. 🍎 [🟢](https://github.com/stonerl/Thaw)
 
+[Move to top](#contents)
+
 ### Wallpaper Tools
 
 - [Lively Wallpaper](https://rocksdanister.com/lively) - Tool to set animated and interactive wallpapers. 🪟 🟢 ⭐
@@ -168,15 +194,23 @@
 - [Variety](https://github.com/varietywalls/variety) - Wallpaper changer with features for downloading and managing wallpapers. 🐧 🟢
 - [WinDynamicDesktop](https://github.com/t1m0thyj/WinDynamicDesktop) - Port of macOS Mojave Dynamic Desktop feature to Windows. 🪟 🟢
 
+[Move to top](#contents)
+
 ## Data Management
+
+[Move to top](#contents)
 
 ### Copy and Move
 
+
+[Move to top](#contents)
 
 ### Sync and Clone
 
 - [FreeFileSync](https://freefilesync.org) - Tool for comparing and syncing files or folders. 🪟 🍎 🐧 🟢 ⭐
 - [Syncthing](https://github.com/syncthing/syncthing) - Continuous file synchronization for multiple computers. 🪟 🍎 🐧 🟢
+
+[Move to top](#contents)
 
 ## Developer Tools
 
@@ -192,6 +226,8 @@
 - [GitHub Desktop](https://desktop.github.com) - Graphical Git client for cloning repositories, reviewing changes, and syncing with GitHub. 🪟 🍎 [🟢](https://github.com/desktop/desktop)
 - [WezTerm](https://wezterm.org) - GPU-accelerated terminal emulator and multiplexer with tabs, panes, SSH, and Lua configuration. 🪟 🍎 🐧 [🟢](https://github.com/wezterm/wezterm)
 
+[Move to top](#contents)
+
 ### API Development
 
 - [Insomnia](https://insomnia.rest) - Simple API client for REST and GraphQL development. 🪟 🍎 🐧 [🟢](https://github.com/Kong/insomnia) ⭐
@@ -204,9 +240,13 @@
 - [SoapUI Open Source](https://soapui.org) - For testing REST and SOAP APIs with scripting support. 🪟 🍎 🐧 [🟢](https://github.com/SmartBear/soapui)
 - [Yaak](https://yaak.app) - An offline and Git friendly API tester for HTTP, GraphQL, WebSockets, SSE, and gRPC. 🪟 🍎 🐧 [🟢](https://github.com/mountain-loop/yaak)
 
+[Move to top](#contents)
+
 ### Database
 
 - [DB Browser for SQLite](https://sqlitebrowser.org) - Visual tool for creating, browsing, and editing SQLite database files. 🪟 🍎 🐧 [🟢](https://github.com/sqlitebrowser/sqlitebrowser)
+
+[Move to top](#contents)
 
 ### Network Analysis
 
@@ -214,6 +254,8 @@
 - [James](https://github.com/james-proxy/james) - Proxy for intercepting HTTP/HTTPS requests. 🪟 🍎 [🟢](https://github.com/james-proxy/james)
 - [mitmproxy](https://mitmproxy.org) - Interactive HTTP proxy for debugging and penetration testing. 🪟 🍎 🐧 [🟢](https://github.com/mitmproxy/mitmproxy)
 - [Sniffnet](https://sniffnet.net) - Tool for monitoring and analyzing network traffic. 🪟 🍎 🐧 [🟢](https://github.com/GyulyVGC/sniffnet)
+
+[Move to top](#contents)
 
 ### Game Engines
 
@@ -227,6 +269,8 @@
 - [Ren'Py](https://github.com/renpy/renpy) - Popular engine for creating visual novels with a simple scripting language. 🪟 🍎 🐧 🟢
 - [Tiled](https://mapeditor.org) - Level editor for creating tile-based game maps, used with other engines. 🪟 🍎 🐧 🟢
 
+[Move to top](#contents)
+
 ### Virtualization
 
 - [Docker](https://docker.com) - Containerization platform for operating-system-level virtualization. 🪟 🍎 🐧 🟢 ⭐
@@ -237,8 +281,12 @@
 - [eryph-zero](https://eryph.io) - Tool for building VMs as if they were running in the cloud, but locally on Windows. 🪟 🟢
 - [Mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS built on Apple's Containerization framework. 🍎 [🟢](https://github.com/us/mocker)
 
+[Move to top](#contents)
+
 ## Documents
 
+
+[Move to top](#contents)
 
 ### Office Suites
 
@@ -246,6 +294,8 @@
 - [Apache OpenOffice](https://openoffice.org) - Suite for documents, spreadsheets, etc. 🪟 🍎 🐧 🟢
 - [OnlyOffice](https://onlyoffice.com) - Office suite with collaboration features. 🪟 🍎 🐧 🟢
 
+
+[Move to top](#contents)
 
 ### E-book
 
@@ -258,6 +308,8 @@
 - [Scribus](https://www.scribus.net) - Layout and publishing software. 🪟 🍎 🐧 [🟢](https://github.com/scribusproject/scribus)
 - [Sigil](https://sigil-ebook.com) - EPUB editor. 🪟 🍎 🐧 [🟢](https://github.com/Sigil-Ebook/Sigil)
 
+[Move to top](#contents)
+
 ### PDF Tools
 
 - [Sumatra PDF](https://sumatrapdfreader.org/free-pdf-reader) - Fast, lightweight PDF reader. 🪟 [🟢](https://github.com/sumatrapdfreader/sumatrapdf) ⭐
@@ -269,6 +321,8 @@
 - [Xournal++](https://xournalpp.github.io) - Handwriting and annotation tool for PDFs. 🪟 🍎 🐧 [🟢](https://github.com/xournalpp/xournalpp)
 - [PDFsam](https://pdfsam.org) - Extract pages, split, merge, mix and rotate PDF files. 🪟 🍎 🐧 [🟢](https://github.com/torakiki/pdfsam)
 
+[Move to top](#contents)
+
 ## Note Taking
 
 - [Inkless](https://github.com/Axorax/inkless) - Minimal, shortcut based app to take notes and use for light coding. 🪟 [🟢](https://github.com/Axorax/inkless) ⭐
@@ -277,6 +331,8 @@
 - [Simplenote](https://simplenote.com) - Minimalist note-taking app that syncs across devices. 🪟 🍎 🐧 [🟢](https://github.com/Automattic/simplenote-electron)
 - [qnote](https://github.com/Omibranch/qnote) - Minimal frameless notepad with Markdown preview, real PDF export via Typst, OCR via Tesseract, and automatic version history. 🐧 [🟢](https://github.com/Omibranch/qnote)
 - [fylepad](https://fylepad.vercel.app) - Lightweight notepad with powerful rich-text editing. 🪟 🍎 🐧 [🟢](https://github.com/imrofayel/fylepad)
+
+[Move to top](#contents)
 
 ## Text Editors
 
@@ -305,6 +361,8 @@
 - [VSCodium](https://vscodium.com) - Community-built VS Code binaries without Microsoft branding, telemetry, or licensing changes. 🪟 🍎 🐧 [🟢](https://github.com/VSCodium/vscodium)
 - [MarkEdit](https://github.com/MarkEdit-app/MarkEdit) - Native Markdown editor for macOS with a TextEdit-like workflow and local-file editing. 🍎 🟢
 
+[Move to top](#contents)
+
 ## Download Managers
 
 - [AB Download Manager](https://abdownloadmanager.com) - Easily download files from anywhere. 🪟 🐧 [🟢](https://github.com/amir1376/ab-download-manager) ⭐
@@ -315,6 +373,8 @@
 - [Xtreme Download Manager (XDM)](https://xtremedownloadmanager.com) - Powerful tool to increase download speed. 🪟 🍎 🐧 [🟢](https://github.com/subhra74/xdm)
 - [Transmission](https://transmissionbt.com) - Lightweight BitTorrent client with native desktop, daemon, and web interfaces. 🪟 🍎 🐧 [🟢](https://github.com/transmission/transmission)
 
+[Move to top](#contents)
+
 ## Games
 
 - [Heroic Games Launcher](https://heroicgameslauncher.com) - Launcher for Epic, GOG. 🪟 🍎 🐧 [🟢](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher)
@@ -322,18 +382,26 @@
 - [Playnite](https://playnite.link) - Unified game library manager. 🪟 [🟢](https://github.com/JosefNemec/Playnite)
 - [ProtonUp-Qt](https://davidotek.github.io/protonup-qt) - Tool for managing Proton/Wine compatibility. 🐧 [🟢](https://github.com/DavidoTek/ProtonUp-Qt)
 
+[Move to top](#contents)
+
 ### Cloud Gaming
 
+
+[Move to top](#contents)
 
 ## Mobile Emulators
 
 - [Waydroid](https://waydro.id) - Container-based approach to boot a full Android system. 🐧 [🟢](https://github.com/waydroid/waydroid)
+
+[Move to top](#contents)
 
 ## Other Emulators
 
 - [RetroArch](https://github.com/libretro/RetroArch) - Open-source, cross-platform emulator that allows to play games from a wide variety of retro gaming consoles and platforms. 🪟 🍎 🐧 🟢 ⭐
 - [DuckStation](https://github.com/stenzek/duckstation) - PlayStation 1 emulator with focus on speed, accuracy, and modern enhancements. 🪟 🍎 🐧 🟢
 - [PCSX-Redux](https://github.com/grumpycoders/pcsx-redux) - PlayStation 1 emulator aimed at advanced debugging and better game compatibility. 🪟 🐧 🟢
+
+[Move to top](#contents)
 
 ## Graphics Tools
 
@@ -344,18 +412,26 @@
 - [Draw.io](https://github.com/jgraph/drawio-desktop) - Desktop app for creating diagrams and flowcharts. 🪟 🍎 🐧 🟢
 - [FontForge](https://fontforge.github.io) - Font editor for creating and modifying font files. 🪟 🍎 🐧 🟢
 
+[Move to top](#contents)
+
 ## 3D Modeling and Animation
 
 - [Blender](https://blender.org) - 3D creation tool supporting modeling, animation, rendering, video editing, and more. 🪟 🍎 🐧 🟢 ⭐
 - [MakeHuman](https://static.makehumancommunity.org/makehuman.html) - 3D human modeler for creating realistic character models. 🪟 🍎 🐧 🟢
 - [Wings 3D](https://www.wings3d.com) - 3D modeling software focusing on subdivision modeling. 🪟 🍎 🐧 🟢
 
+[Move to top](#contents)
+
 ## Security
+
+[Move to top](#contents)
 
 ### Antivirus
 
 - [ClamAV](https://www.clamav.net) - Antivirus engine for detecting malware, viruses, and other threats. 🪟 🍎 🐧 🟢
 - [Pareto Security](https://paretosecurity.com/apps) - Check for basic security hygiene of any Windows, Mac or Linux desktop. 🪟 🍎 🐧 [🟢](https://github.com/paretoSecurity/agent)
+
+[Move to top](#contents)
 
 ### Password Managers
 
@@ -363,14 +439,20 @@
 - [Passbolt](https://passbolt.com) - Team-oriented password manager for sharing and storing passwords securely. 🪟 🍎 🐧 🟢
 - [ProtonPass](https://proton.me/pass) - Free password manager with end-to-end encryption based in Switzerland. 🪟 🍎 🐧 [🟢](https://github.com/protonpass)
 
+[Move to top](#contents)
+
 ### Ad & Tracker Blocking
 
 - [SaneHosts](https://sanehosts.com) - macOS hosts file manager for system-wide ad and tracker blocking. 🍎 [🟢](https://github.com/sane-apps/SaneHosts)
+
+[Move to top](#contents)
 
 ## Image Viewers
 
 - [ImageGlass](https://imageglass.org) - Lightweight, versatile image viewer. 🪟 🟢 ⭐
 - [FlowVision](https://github.com/netdcy/FlowVision) - Waterfall-style image viewer. 🍎 🟢
+
+[Move to top](#contents)
 
 ## Remote Access
 
@@ -378,8 +460,12 @@
 - [RustDesk](https://rustdesk.com) - Remote desktop software with a focus on simplicity and security. 🪟 🍎 🐧 🟢
 - [Sunshine](https://github.com/LizardByte/Sunshine) - Self-hosted game streaming server for use with Moonlight. 🪟 🍎 🐧 🟢
 
+[Move to top](#contents)
+
 ## Video
 
+
+[Move to top](#contents)
 
 ### Video Editors
 
@@ -390,6 +476,8 @@
 - [Avidemux](https://avidemux.sourceforge.net) - Video editor designed for simple cutting, filtering and encoding tasks. 🪟 🍎 🐧 [🟢](https://github.com/mean00/avidemux2)
 - [lossless-cut](https://losslesscut.app) - Swiss army knife of lossless video/audio editing. 🪟 🍎 🐧 [🟢](https://github.com/mifi/lossless-cut)
 
+[Move to top](#contents)
+
 ### Video Players
 
 - [IINA](https://iina.io) - Media player that claims to perform better than VLC. 🍎 🟢
@@ -397,6 +485,8 @@
 - [MPV](https://mpv.io) - Cross-platform media player with a simple interface. 🪟 🍎 🐧 🟢
 - [MPC-HC](https://github.com/clsid2/mpc-hc) - Lightweight video player with support for all common formats. 🪟 🟢
 - [VLC Media Player](https://videolan.org/vlc) - Media player supporting almost all video formats. 🪟 🍎 🐧 🟢
+
+[Move to top](#contents)
 
 ### Video Streaming and Recording
 
@@ -408,12 +498,16 @@
 - [Streamlabs Desktop](https://streamlabs.com) - Streaming software with customizable alerts and overlays. 🪟 🍎 🟢
 - [ScreenToGif](https://www.screentogif.com) - Record, edit, and create animated GIFs from your screen. 🪟 [🟢](https://github.com/NickeManarin/ScreenToGif)
 
+[Move to top](#contents)
+
 ### Video Converters and Compressors
 
 - [FFmpeg](https://ffmpeg.org) - Powerful tool for format conversion and multimedia editing. 🪟 🍎 🐧 🟢 ⭐
 - [FastFlix](https://github.com/cdgriffith/FastFlix) - GUI for fast encoding with H.264, HEVC, and AV1 support. 🪟 🟢
 - [HandBrake](https://handbrake.fr) - Video transcoder with preset profiles for device compatibility. 🪟 🍎 🐧 🟢
 - [VidCoder](https://vidcoder.net) - User-friendly HandBrake-based transcoder with batch processing. 🪟 🍎 🟢
+
+[Move to top](#contents)
 
 ## VPN and Proxy Tools
 
@@ -430,6 +524,8 @@
 - [Tunnelblick](https://github.com/Tunnelblick/Tunnelblick) - Easy-to-use OpenVPN client with a macOS-friendly interface. 🍎 🟢
 - [v2rayN](https://github.com/2dust/v2rayN) - Open source GUI for Xray and Sing-box. 🪟 🍎 🐧 🟢
 - [WireGuard](https://wireguard.com) - Fast, secure VPN protocol designed for simplicity. 🪟 🍎 🐧 [🟢](https://www.wireguard.com/repositories)
+
+[Move to top](#contents)
 
 ## Utility
 
@@ -452,6 +548,8 @@
 - [MonitorControl](https://monitorcontrol.app) - Controls external display brightness, volume, and contrast from macOS keyboard shortcuts and menu bar. 🍎 [🟢](https://github.com/MonitorControl/MonitorControl)
 - [balenaEtcher](https://etcher.balena.io) - Tool for safely flashing OS images to SD cards and USB drives. 🪟 🍎 🐧 [🟢](https://github.com/balena-io/etcher)
 
+[Move to top](#contents)
+
 ### Clipboard Management
 
 - [Clipy](https://clipy-app.com) - Simple clipboard manager. 🍎 🟢
@@ -462,9 +560,13 @@
 - [Qopy](https://github.com/0pandadev/qopy) - Minimalist clipboard manager with unique features. 🪟 🍎 🐧 🟢
 - [SaneClip](https://saneclip.com) - Clipboard manager that keeps all history local with search and formatting tools. 🍎 [🟢](https://github.com/sane-apps/SaneClip)
 
+[Move to top](#contents)
+
 ### Metadata
 
 
+
+[Move to top](#contents)
 
 ### Window Management
 
@@ -479,6 +581,8 @@
 - [Niri](https://github.com/niri-wm/niri) - Scrollable-tiling Wayland compositor written in Rust. 🐧 🟢
 - [AltTab](https://alt-tab.app) - Window switcher that brings Windows-style alt-tab previews and controls to macOS. 🍎 [🟢](https://github.com/lwouis/alt-tab-macos)
 
+[Move to top](#contents)
+
 ### File Management
 
 - [Files](https://files.community/download) - Modern file manager for easy file organization. 🪟 [🟢](https://github.com/files-community/Files)
@@ -486,10 +590,14 @@
 - [Sigma File Manager](https://github.com/aleksey-hoffman/sigma-file-manager) - Modern file manager with advanced features. 🪟 🐧 [🟢](https://github.com/aleksey-hoffman/sigma-file-manager)
 - [Cyberduck](https://cyberduck.io) - File transfer client for FTP, SFTP, WebDAV, S3, Azure, OneDrive, and other storage services. 🪟 🍎 [🟢](https://github.com/iterate-ch/cyberduck)
 
+[Move to top](#contents)
+
 ### Application Management
 
 - [Bulk Crap Uninstaller](https://www.bcuninstaller.com) - Powerful tool for uninstalling multiple applications and cleaning leftovers. 🪟 🟢 ⭐
 - [PureMac](https://github.com/momenbasel/PureMac) - macOS app manager and system cleaner for uninstalling apps, removing orphaned files, and cleaning caches. 🍎 🟢
+
+[Move to top](#contents)
 
 ### Screenshot
 
@@ -499,9 +607,13 @@
 - [Greenshot](https://getgreenshot.org) - Screenshot tool for Windows that allows capturing, annotating, and editing screenshots. 🪟 🟢
 - [Snipaste](https://snipaste.com) - Free, Customizable, Portable snipping tool.
 
+[Move to top](#contents)
+
 ### Space Visualizer
 
 - [ClearDisk](https://github.com/bysiber/cleardisk) - macOS menu bar app to visualize and clean developer caches (Xcode, node_modules, CocoaPods, Docker, pip, Cargo). 🍎 [🟢](https://github.com/bysiber/cleardisk)
+
+[Move to top](#contents)
 
 ### Trackpad
 

--- a/filter/recommended-mobile-only.md
+++ b/filter/recommended-mobile-only.md
@@ -79,152 +79,256 @@
 
 ## Audio
 
+[Move to top](#contents)
+
 ### Audio Players
 
+
+[Move to top](#contents)
 
 ### Audio Recording
 
 
+[Move to top](#contents)
+
 ### DJ Software
 
 
+[Move to top](#contents)
+
 ### Music Notation
 
+
+[Move to top](#contents)
 
 ### Music Production
 
 
 
+[Move to top](#contents)
+
 ## Browsers
 
 
+[Move to top](#contents)
+
 ## Communication
+
+[Move to top](#contents)
 
 ### Messaging
 
 
+[Move to top](#contents)
+
 ### Email Clients
 
+
+[Move to top](#contents)
 
 ## Compression and Archiving
 
 
+[Move to top](#contents)
+
 ## Customize
+
+[Move to top](#contents)
 
 ### System Customization
 
 
+[Move to top](#contents)
+
 ### Wallpaper Tools
 
 
+[Move to top](#contents)
+
 ## Data Management
+
+[Move to top](#contents)
 
 ### Copy and Move
 
 
+[Move to top](#contents)
+
 ### Sync and Clone
 
+
+[Move to top](#contents)
 
 ## Developer Tools
 
 
+[Move to top](#contents)
+
 ### API Development
 
+
+[Move to top](#contents)
 
 ### Database
 
 
+[Move to top](#contents)
+
 ### Network Analysis
 
+
+[Move to top](#contents)
 
 ### Game Engines
 
 
+[Move to top](#contents)
+
 ### Virtualization
 
 
+[Move to top](#contents)
+
 ## Documents
+
+[Move to top](#contents)
 
 ### Office Suites
 
 
+[Move to top](#contents)
+
 ### E-book
 
+
+[Move to top](#contents)
 
 ### PDF Tools
 
 
+[Move to top](#contents)
+
 ## Note Taking
 
+
+[Move to top](#contents)
 
 ## Text Editors
 
 
+[Move to top](#contents)
+
 ## Finance
 
+
+[Move to top](#contents)
 
 ## Download Managers
 
 
+[Move to top](#contents)
+
 ## Graphics Tools
 
+
+[Move to top](#contents)
 
 ## 3D Modeling and Animation
 
 
+[Move to top](#contents)
+
 ## Security
+
+[Move to top](#contents)
 
 ### Antivirus
 
 
+[Move to top](#contents)
+
 ### Password Managers
 
+
+[Move to top](#contents)
 
 ## Image Viewers
 
 
+[Move to top](#contents)
+
 ## Remote Access
 
 
+[Move to top](#contents)
+
 ## Video
+
+[Move to top](#contents)
 
 ### Video Editors
 
 
+[Move to top](#contents)
+
 ### Video Players
 
+
+[Move to top](#contents)
 
 ### Video Streaming and Recording
 
 
+[Move to top](#contents)
+
 ### Video Converters and Compressors
 
+
+[Move to top](#contents)
 
 ## VPN and Proxy Tools
 
 
+[Move to top](#contents)
+
 ## Health and Wellness
 
 
+[Move to top](#contents)
+
 ## Utility
+
+[Move to top](#contents)
 
 ### Clipboard Management
 
 
+[Move to top](#contents)
+
 ### Metadata
 
+
+[Move to top](#contents)
 
 ### Window Management
 
 
+[Move to top](#contents)
+
 ### File Management
 
+
+[Move to top](#contents)
 
 ### Application Management
 
 
+[Move to top](#contents)
+
 ### Screenshot
 
+
+[Move to top](#contents)
 
 ### Space Visualizer
 

--- a/filter/recommended-only.md
+++ b/filter/recommended-only.md
@@ -87,134 +87,202 @@
 
 - [FXSound](https://fxsound.com) - Boost sound quality, volume, and bass. Has a beautiful modern UI. 🪟 🟢 ⭐
 
+[Move to top](#contents)
+
 ### Audio Players
 
 - [Foobar2000](https://foobar2000.org) - Lightweight and highly customizable audio player with support for many formats. 🪟 🍎 ⭐
+
+[Move to top](#contents)
 
 ### Audio Recording
 
 - [Audacity](https://audacityteam.org/download) - Audio editor for recording and editing sounds. 🪟 🍎 🐧 🟢 ⭐
 
+[Move to top](#contents)
+
 ### DJ Software
 
 
+[Move to top](#contents)
+
 ### Music Notation
 
+
+[Move to top](#contents)
 
 ### Music Production
 
 - [LMMS](https://lmms.io) - DAW for creating music with virtual instruments and MIDI support. 🪟 🍎 🐧 🟢 ⭐
 
+[Move to top](#contents)
+
 ## Browsers
 
 - [Tor Browser](https://torproject.org/projects/torbrowser.html) - Privacy browser routing traffic over the Tor network. 🪟 🍎 🐧 [🟢](https://gitlab.torproject.org/tpo/applications/tor-browser) ⭐
 
+[Move to top](#contents)
+
 ## Communication
+
+[Move to top](#contents)
 
 ### Messaging
 
 - [Discord](https://discord.com) - Communication platform for text, voice, and video, popular with gamers. 🪟 🍎 🐧 ⭐
 
+[Move to top](#contents)
+
 ### Email Clients
 
+
+[Move to top](#contents)
 
 ## Compression and Archiving
 
 - [7-Zip](https://7-zip.org/download.html) - Archive manager supporting 7z, ZIP, and other formats. 🪟 🟢 ⭐
 
+[Move to top](#contents)
+
 ## Customize
+
+[Move to top](#contents)
 
 ### System Customization
 
+
+[Move to top](#contents)
 
 ### Wallpaper Tools
 
 - [Lively Wallpaper](https://rocksdanister.com/lively) - Tool to set animated and interactive wallpapers. 🪟 🟢 ⭐
 - [Rainmeter](https://rainmeter.net) - Desktop customization tool offering widgets, skins, and live stats. 🪟 🟢 ⭐
 
+[Move to top](#contents)
+
 ## Data Management
+
+[Move to top](#contents)
 
 ### Copy and Move
 
 - [Blip](https://blip.net) - Direct file transfer app with unlimited file sizes, folder support, and transfer resume. 🪟 🍎 ⭐
 
+[Move to top](#contents)
+
 ### Sync and Clone
 
 - [FreeFileSync](https://freefilesync.org) - Tool for comparing and syncing files or folders. 🪟 🍎 🐧 🟢 ⭐
+
+[Move to top](#contents)
 
 ## Developer Tools
 
 - [livewinsize](https://github.com/Axorax/livewinsize) - Visualize window size in pixels and other units. 🪟 🟢 ⭐
 - [TkForge](https://github.com/Axorax/tkforge) - Drag & drop in Figma to create a Python GUI with ease. 🪟 🍎 🐧 🟢 ⭐
 
+[Move to top](#contents)
+
 ### API Development
 
 - [Insomnia](https://insomnia.rest) - Simple API client for REST and GraphQL development. 🪟 🍎 🐧 [🟢](https://github.com/Kong/insomnia) ⭐
 - [Postman](https://postman.com) - API development platform with advanced testing and collaboration tools. 🪟 🍎 🐧 ⭐
 
+[Move to top](#contents)
+
 ### Database
 
 - [DBeaver](https://dbeaver.io) - Universal database tool for SQL databases like MySQL, MariaDB, PostgreSQL, SQLite, Apache Family, and more. 🪟 🍎 🐧 ⭐
 
+[Move to top](#contents)
+
 ### Network Analysis
 
 - [Wireshark](https://wireshark.org) - Leading tool for capturing and analyzing network traffic. 🪟 🍎 🐧 [🟢](https://gitlab.com/wireshark/wireshark) ⭐
+
+[Move to top](#contents)
 
 ### Game Engines
 
 - [Godot](https://godotengine.org) - Game engine for 2D and 3D games with an easy-to-learn scripting language. 🪟 🍎 🐧 🟢 ⭐
 - [Unreal Engine](https://unrealengine.com) - Powerful, fully-featured game engine for high-quality 3D games. 🪟 🍎 🐧 ⭐
 
+[Move to top](#contents)
+
 ### Virtualization
 
 - [Docker](https://docker.com) - Containerization platform for operating-system-level virtualization. 🪟 🍎 🐧 🟢 ⭐
 - [VirtualBox](https://www.virtualbox.org) - Virtualization software for creating and managing virtual machines. 🪟 🍎 🐧 ⭐
 
+[Move to top](#contents)
+
 ## Documents
 
+
+[Move to top](#contents)
 
 ### Office Suites
 
 - [LibreOffice](https://libreoffice.org) - Popular and easy to use office suite. 🪟 🍎 🐧 🟢 ⭐
 
 
+[Move to top](#contents)
+
 ### E-book
 
 - [Calibre](https://calibre-ebook.com) - Powerful e-book manager. 🪟 🍎 🐧 [🟢](https://github.com/kovidgoyal/calibre) ⭐
 - [IReader](https://github.com/IReaderorg/IReader) Free and open source novel reader for Android and Desktop
 
+[Move to top](#contents)
+
 ### PDF Tools
 
 - [Sumatra PDF](https://sumatrapdfreader.org/free-pdf-reader) - Fast, lightweight PDF reader. 🪟 [🟢](https://github.com/sumatrapdfreader/sumatrapdf) ⭐
+
+[Move to top](#contents)
 
 ## Note Taking
 
 - [Inkless](https://github.com/Axorax/inkless) - Minimal, shortcut based app to take notes and use for light coding. 🪟 [🟢](https://github.com/Axorax/inkless) ⭐
 - [Obsidian](https://obsidian.md) - Knowledge base app with powerful linking and markdown support. 🪟 🍎 🐧 ⭐
 
+[Move to top](#contents)
+
 ## Text Editors
 
 - [Visual Studio Code](https://code.visualstudio.com) - Code editor with debugging, integrated Git support, and a vast extension marketplace. 🪟 🍎 🐧 [🟢](https://github.com/microsoft/vscode) ⭐
+
+[Move to top](#contents)
 
 ## Download Managers
 
 - [AB Download Manager](https://abdownloadmanager.com) - Easily download files from anywhere. 🪟 🐧 [🟢](https://github.com/amir1376/ab-download-manager) ⭐
 - [Free Download Manager](https://freedownloadmanager.org) - Modern download accelerator. 🪟 🍎 🐧 ⭐
 
+[Move to top](#contents)
+
 ## Games
 
 - [Steam](https://store.steampowered.com) - Platform for buying and playing PC games. 🪟 🍎 🐧 ⭐
 
+[Move to top](#contents)
+
 ### Cloud Gaming
 
+
+[Move to top](#contents)
 
 ## Mobile Emulators
 
 - [BlueStacks](https://www.bluestacks.com) - Android emulator for playing mobile games on PC. 🪟 🍎 ⭐
 
+[Move to top](#contents)
+
 ## Other Emulators
 
 - [RetroArch](https://github.com/libretro/RetroArch) - Open-source, cross-platform emulator that allows to play games from a wide variety of retro gaming consoles and platforms. 🪟 🍎 🐧 🟢 ⭐
+
+[Move to top](#contents)
 
 ## Graphics Tools
 
@@ -222,49 +290,77 @@
 - [Inkscape](https://inkscape.org/en) - Vector graphics editor used for creating logos, illustrations, and more. 🪟 🍎 🐧 🟢 ⭐
 - [Krita](https://krita.org) - Digital painting software designed for illustrators and concept artists. 🪟 🍎 🐧 🟢 ⭐
 
+[Move to top](#contents)
+
 ## 3D Modeling and Animation
 
 - [Blender](https://blender.org) - 3D creation tool supporting modeling, animation, rendering, video editing, and more. 🪟 🍎 🐧 🟢 ⭐
 
+[Move to top](#contents)
+
 ## Security
+
+[Move to top](#contents)
 
 ### Antivirus
 
 
+[Move to top](#contents)
+
 ### Password Managers
 
 
+[Move to top](#contents)
+
 ### Ad & Tracker Blocking
 
+
+[Move to top](#contents)
 
 ## Image Viewers
 
 - [ImageGlass](https://imageglass.org) - Lightweight, versatile image viewer. 🪟 🟢 ⭐
 
+[Move to top](#contents)
+
 ## Remote Access
 
 
+[Move to top](#contents)
+
 ## Video
 
+
+[Move to top](#contents)
 
 ### Video Editors
 
 - [DaVinci Resolve](https://blackmagicdesign.com/products/davinciresolve) - Professional video editor with advanced color correction and effects. 🪟 🍎 🐧 ⭐
 
+[Move to top](#contents)
+
 ### Video Players
 
 - [PotPlayer](https://potplayer.tv/) - Feature-rich video player with advanced playback options. 🪟 ⭐
+
+[Move to top](#contents)
 
 ### Video Streaming and Recording
 
 - [OBS Studio](https://obsproject.com) - Software for live streaming and recording video. 🪟 🍎 🐧 🟢 ⭐
 
+[Move to top](#contents)
+
 ### Video Converters and Compressors
 
 - [FFmpeg](https://ffmpeg.org) - Powerful tool for format conversion and multimedia editing. 🪟 🍎 🐧 🟢 ⭐
 
+[Move to top](#contents)
+
 ## VPN and Proxy Tools
 
+
+[Move to top](#contents)
 
 ## Utility
 
@@ -272,35 +368,51 @@
 - [PowerToys](https://learn.microsoft.com/en-us/windows/powertoys) - Utilities for file renaming, resizing, and productivity tools. 🪟 [🟢](https://github.com/microsoft/PowerToys) ⭐
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp) - Command-line tool for downloading audio and video. 🪟 🍎 🐧 [🟢](https://github.com/yt-dlp/yt-dlp) ⭐
 
+[Move to top](#contents)
+
 ### Clipboard Management
 
+
+[Move to top](#contents)
 
 ### Metadata
 
 - [ExifTool](https://exiftool.org) - Command-line tool for editing metadata in various file types. 🪟 🍎 🐧 ⭐
 
 
+[Move to top](#contents)
+
 ### Window Management
 
 - [FancyZones](https://github.com/microsoft/PowerToys) - Snap and arrange windows in multi-monitor setups. 🪟 🟢 ⭐
 - [Rectangle](https://rectangleapp.com) - Efficient window manager with keyboard shortcut support. 🍎 ⭐
 
+[Move to top](#contents)
+
 ### File Management
 
 - [Everything](https://voidtools.com) - Fast file search tool indexing the entire file system. 🪟 ⭐
 
+[Move to top](#contents)
+
 ### Application Management
 
 - [Bulk Crap Uninstaller](https://www.bcuninstaller.com) - Powerful tool for uninstalling multiple applications and cleaning leftovers. 🪟 🟢 ⭐
+
+[Move to top](#contents)
 
 ### Screenshot
 
 - [ShareX](https://getsharex.com) - Powerful screenshot and screen recording tool with advanced editing options. 🪟 🟢 ⭐
 - [Snipaste](https://snipaste.com) - Free, Customizable, Portable snipping tool.
 
+[Move to top](#contents)
+
 ### Space Visualizer
 
 - [WizTree](https://diskanalyzer.com) - Fast disk space analyzer that scans drives and shows file size distribution. 🪟 ⭐
+
+[Move to top](#contents)
 
 ### Trackpad
 

--- a/filter/windows-only.md
+++ b/filter/windows-only.md
@@ -90,6 +90,8 @@
 - [EarTrumpet](https://eartrumpet.app) - Advanced volume control for Windows, offering app-specific audio management. 🪟
 - [Ambie](https://github.com/jenius-apps/ambie) - Use white noise, nature sounds, & more to boost your productivity. 🪟 🟢
 
+[Move to top](#contents)
+
 ### Audio Players
 
 - [Foobar2000](https://foobar2000.org) - Lightweight and highly customizable audio player with support for many formats. 🪟 🍎 ⭐
@@ -98,11 +100,15 @@
 - [MusicBee](https://getmusicbee.com) - Feature-rich music player and manager. 🪟
 - [Strawberry Music Player](https://strawberrymusicplayer.org) - Music player for organizing and playing your audio collection. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ### Audio Recording
 
 - [Audacity](https://audacityteam.org/download) - Audio editor for recording and editing sounds. 🪟 🍎 🐧 🟢 ⭐
 - [Ocenaudio](https://ocenaudio.com) - Easy-to-use audio editor for recording and analyzing sounds. 🪟 🍎 🐧
 - [Wavosaur](https://www.wavosaur.com) - Simple audio editor for recording, editing, and processing sound. 🪟
+
+[Move to top](#contents)
 
 ### DJ Software
 
@@ -112,6 +118,8 @@
 - [Rekordbox](https://rekordbox.com/en) - Software that enables a comfortable DJ workflow with AI, cloud, and automation tech. 🪟 🍎
 - [VirtualDJ](https://virtualdj.com) - DJ platform for mixing music, beatmatching, and live performance. 🪟 🍎
 
+[Move to top](#contents)
+
 ### Music Notation
 
 - [ABCjs](https://abcjs.net) - Tool for writing and playing ABC music notation. 🪟 🍎 🐧
@@ -119,6 +127,8 @@
 - [Frescobaldi](https://frescobaldi.org) - Editor for LilyPond to create music scores quickly. 🪟 🍎 🐧
 - [LilyPond](https://lilypond.org) - Music notation program for creating high-quality sheet music. 🪟 🍎 🐧
 - [MuseScore](https://musescore.org) - Software for creating, playing, and sharing sheet music. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ### Music Production
 
@@ -130,6 +140,8 @@
 - [OpenMPT](https://openmpt.org) - Modren tracker software that can open multiple tracker formats. 🪟
 - [Stargate DAW](https://github.com/stargatedaw/stargate) - Innovation-first DAW, instrument and effect plugins. 🪟 🍎 🐧 🟢
 - [Tracktion T7](https://tracktion.com/products/t7-daw) - DAW for music production with advanced editing features. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ## Browsers
 
@@ -151,7 +163,11 @@
 - [Vivaldi](https://vivaldi.com) - Customizable browser putting you in control. 🪟 🍎 🐧
 - [Zen Browser](https://zen-browser.app) - Beautifully designed, privacy-focused browser with custom mods. 🪟 🍎 🐧 [🟢](https://github.com/zen-browser/desktop)
 
+[Move to top](#contents)
+
 ## Communication
+
+[Move to top](#contents)
 
 ### Messaging
 
@@ -163,6 +179,8 @@
 - [Viber](https://viber.com) - Free messaging app with text, voice, video calls, and file sharing. 🪟 🍎 🐧
 - [Microsoft Teams](https://microsoft.com/en-us/microsoft-teams/group-chat-software) - Team communication platform with chat, file sharing, and video conferencing. 🪟 🍎 🐧
 - [Skype](https://skype.com) - Messaging and video call service supporting text, voice, and video. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ### Email Clients
 
@@ -181,6 +199,8 @@
 - [ThunderBird](https://thunderbird.net) - Email client for easier management. 🪟 🍎 🐧 🟢
 - [Tutanota](https://tutanota.com) - Encrypted service focused on privacy. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ## Compression and Archiving
 
 - [7-Zip](https://7-zip.org/download.html) - Archive manager supporting 7z, ZIP, and other formats. 🪟 🟢 ⭐
@@ -188,7 +208,11 @@
 - [NanaZip](https://apps.microsoft.com/detail/9n8g7tscl18r?hl=en-us&gl=US) - 7-Zip derivative optimized for Windows 10/11 with added functionality. 🪟
 - [PeaZip](https://peazip.github.io) - Archive manager supporting 180+ formats with encryption and compression. 🪟 🐧 🟢
 
+[Move to top](#contents)
+
 ## Customize
+
+[Move to top](#contents)
 
 ### System Customization
 
@@ -204,6 +228,8 @@
 - [Sophia Script for Windows](https://github.com/farag2/Sophia-Script-for-Windows) - The most powerful PowerShell module for fine-tuning Windows showing how Windows can be configured without making any harm to it. 🪟 [🟢](https://github.com/farag2/Sophia-Script-for-Windows)
 - [RetroBar](https://github.com/dremin/RetroBar) - Classic Windows 95, 98, Me, 2000, XP, Vista taskbar for modern versions of Windows. 🪟 [🟢](https://github.com/dremin/RetroBar)
 
+[Move to top](#contents)
+
 ### Wallpaper Tools
 
 - [Lively Wallpaper](https://rocksdanister.com/lively) - Tool to set animated and interactive wallpapers. 🪟 🟢 ⭐
@@ -211,7 +237,11 @@
 - [ScreenPlay](https://github.com/kelteseth/ScreenPlay) - Wallpaper and widget engine. 🪟 🐧 🟢
 - [WinDynamicDesktop](https://github.com/t1m0thyj/WinDynamicDesktop) - Port of macOS Mojave Dynamic Desktop feature to Windows. 🪟 🟢
 
+[Move to top](#contents)
+
 ## Data Management
+
+[Move to top](#contents)
 
 ### Copy and Move
 
@@ -219,11 +249,15 @@
 - [TeraCopy](https://codesector.com/teracopy) - Copy and move multiple files. 🪟 🍎
 - [Blip](https://blip.net) - Direct file transfer app with unlimited file sizes, folder support, and transfer resume. 🪟 🍎 ⭐
 
+[Move to top](#contents)
+
 ### Sync and Clone
 
 - [FreeFileSync](https://freefilesync.org) - Tool for comparing and syncing files or folders. 🪟 🍎 🐧 🟢 ⭐
 - [rclone](https://rclone.org) - Command-line tool for managing and syncing files with cloud storage. 🪟 🍎 🐧
 - [Syncthing](https://github.com/syncthing/syncthing) - Continuous file synchronization for multiple computers. 🪟 🍎 🐧 🟢
+
+[Move to top](#contents)
 
 ## Developer Tools
 
@@ -239,6 +273,8 @@
 - [GitHub Desktop](https://desktop.github.com) - Graphical Git client for cloning repositories, reviewing changes, and syncing with GitHub. 🪟 🍎 [🟢](https://github.com/desktop/desktop)
 - [WezTerm](https://wezterm.org) - GPU-accelerated terminal emulator and multiplexer with tabs, panes, SSH, and Lua configuration. 🪟 🍎 🐧 [🟢](https://github.com/wezterm/wezterm)
 
+[Move to top](#contents)
+
 ### API Development
 
 - [Insomnia](https://insomnia.rest) - Simple API client for REST and GraphQL development. 🪟 🍎 🐧 [🟢](https://github.com/Kong/insomnia) ⭐
@@ -253,11 +289,15 @@
 - [SoapUI Open Source](https://soapui.org) - For testing REST and SOAP APIs with scripting support. 🪟 🍎 🐧 [🟢](https://github.com/SmartBear/soapui)
 - [Yaak](https://yaak.app) - An offline and Git friendly API tester for HTTP, GraphQL, WebSockets, SSE, and gRPC. 🪟 🍎 🐧 [🟢](https://github.com/mountain-loop/yaak)
 
+[Move to top](#contents)
+
 ### Database
 
 - [DBeaver](https://dbeaver.io) - Universal database tool for SQL databases like MySQL, MariaDB, PostgreSQL, SQLite, Apache Family, and more. 🪟 🍎 🐧 ⭐
 - [Beekeeper Studio](https://beekeeperstudio.io) - Modern, lightweight SQL client supporting MySQL, Postgres, SQLite, SQL Server, etc. 🪟 🍎 🐧
 - [DB Browser for SQLite](https://sqlitebrowser.org) - Visual tool for creating, browsing, and editing SQLite database files. 🪟 🍎 🐧 [🟢](https://github.com/sqlitebrowser/sqlitebrowser)
+
+[Move to top](#contents)
 
 ### Network Analysis
 
@@ -267,6 +307,8 @@
 - [James](https://github.com/james-proxy/james) - Proxy for intercepting HTTP/HTTPS requests. 🪟 🍎 [🟢](https://github.com/james-proxy/james)
 - [mitmproxy](https://mitmproxy.org) - Interactive HTTP proxy for debugging and penetration testing. 🪟 🍎 🐧 [🟢](https://github.com/mitmproxy/mitmproxy)
 - [Sniffnet](https://sniffnet.net) - Tool for monitoring and analyzing network traffic. 🪟 🍎 🐧 [🟢](https://github.com/GyulyVGC/sniffnet)
+
+[Move to top](#contents)
 
 ### Game Engines
 
@@ -292,6 +334,8 @@
 - [Tiled](https://mapeditor.org) - Level editor for creating tile-based game maps, used with other engines. 🪟 🍎 🐧 🟢
 - [Unity](https://unity.com) - Popular game engine for creating both 2D and 3D games, with an intuitive interface and wide asset store. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ### Virtualization
 
 - [Docker](https://docker.com) - Containerization platform for operating-system-level virtualization. 🪟 🍎 🐧 🟢 ⭐
@@ -304,9 +348,13 @@
 - [VMWare Workstation](https://vmware.com/products/desktop-hypervisor/workstation-and-fusion) - Virtualization software with advanced features. 🪟 🍎 🐧
 - [eryph-zero](https://eryph.io) - Tool for building VMs as if they were running in the cloud, but locally on Windows. 🪟 🟢
 
+[Move to top](#contents)
+
 ## Documents
 
 - [CDisplayEx](https://www.cdisplayex.com) - Lightweight comic book reader (.cbr, .cbz, .pdf, manga). 🪟
+
+[Move to top](#contents)
 
 ### Office Suites
 
@@ -321,6 +369,8 @@
 - [WPS Office](https://wps.com) - Lightweight office suite compatible with MS file formats. 🪟 🍎 🐧
 
 
+[Move to top](#contents)
+
 ### E-book
 
 - [Calibre](https://calibre-ebook.com) - Powerful e-book manager. 🪟 🍎 🐧 [🟢](https://github.com/kovidgoyal/calibre) ⭐
@@ -331,6 +381,8 @@
 - [Readest](https://readest.com) - Cross-platform eBook reader with tools. 🪟 🍎 🐧 [🟢](https://github.com/readest/readest)
 - [Scribus](https://www.scribus.net) - Layout and publishing software. 🪟 🍎 🐧 [🟢](https://github.com/scribusproject/scribus)
 - [Sigil](https://sigil-ebook.com) - EPUB editor. 🪟 🍎 🐧 [🟢](https://github.com/Sigil-Ebook/Sigil)
+
+[Move to top](#contents)
 
 ### PDF Tools
 
@@ -344,6 +396,8 @@
 - [PDFGear](https://www.pdfgear.com) - Read, edit, convert, merge, and sign PDF files across devices. 🪟 🍎
 - [PDFsam](https://pdfsam.org) - Extract pages, split, merge, mix and rotate PDF files. 🪟 🍎 🐧 [🟢](https://github.com/torakiki/pdfsam)
 
+[Move to top](#contents)
+
 ## Note Taking
 
 - [Inkless](https://github.com/Axorax/inkless) - Minimal, shortcut based app to take notes and use for light coding. 🪟 [🟢](https://github.com/Axorax/inkless) ⭐
@@ -355,6 +409,8 @@
 - [RemNote](https://remnote.io) - Knowledge management app with note-taking and spaced repetition features. 🪟 🍎 🐧
 - [Simplenote](https://simplenote.com) - Minimalist note-taking app that syncs across devices. 🪟 🍎 🐧 [🟢](https://github.com/Automattic/simplenote-electron)
 - [fylepad](https://fylepad.vercel.app) - Lightweight notepad with powerful rich-text editing. 🪟 🍎 🐧 [🟢](https://github.com/imrofayel/fylepad)
+
+[Move to top](#contents)
 
 ## Text Editors
 
@@ -380,6 +436,8 @@
 - [MDLook](https://mdlook.com) - Portable offline Markdown editor using WebView2 with live preview, dark mode, and diagram support. 🪟
 - [VSCodium](https://vscodium.com) - Community-built VS Code binaries without Microsoft branding, telemetry, or licensing changes. 🪟 🍎 🐧 [🟢](https://github.com/VSCodium/vscodium)
 
+[Move to top](#contents)
+
 ## Download Managers
 
 - [AB Download Manager](https://abdownloadmanager.com) - Easily download files from anywhere. 🪟 🐧 [🟢](https://github.com/amir1376/ab-download-manager) ⭐
@@ -391,6 +449,8 @@
 - [Persepolis Download Manager](https://persepolisdm.github.io) - GUI for Aria2, providing an intuitive interface. 🪟 🍎 🐧 [🟢](https://github.com/persepolisdm/persepolis)
 - [Xtreme Download Manager (XDM)](https://xtremedownloadmanager.com) - Powerful tool to increase download speed. 🪟 🍎 🐧 [🟢](https://github.com/subhra74/xdm)
 - [Transmission](https://transmissionbt.com) - Lightweight BitTorrent client with native desktop, daemon, and web interfaces. 🪟 🍎 🐧 [🟢](https://github.com/transmission/transmission)
+
+[Move to top](#contents)
 
 ## Games
 
@@ -410,12 +470,16 @@
 - [Playnite](https://playnite.link) - Unified game library manager. 🪟 [🟢](https://github.com/JosefNemec/Playnite)
 - [Ubisoft Connect](https://ubisoftconnect.com) - Game launcher for Ubisoft titles. 🪟 🍎
 
+[Move to top](#contents)
+
 ### Cloud Gaming
 
 - [Antstream Arcade](https://www.antstream.com) - Free tier with retro games playable via the cloud. 🪟 🍎 🐧
 - [Boosteroid](https://boosteroid.com) - Free plan available for limited game streaming. 🪟 🍎 🐧
 - [NVIDIA GeForce NOW](https://www.nvidia.com/en-us/geforce-now) - Free tier for streaming supported games from the cloud. 🪟 🍎 🐧
 - [Xbox Cloud Gaming](https://www.xbox.com/en-US/play) - Free trial with limited titles via the cloud. 🪟 🍎
+
+[Move to top](#contents)
 
 ## Mobile Emulators
 
@@ -426,6 +490,8 @@
 - [KoPlayer](https://koplayerpc.com) - Android emulator optimized for gaming and streaming. 🪟
 - [MEmu Play](https://memuplay.com) - Powerful Android emulator with excellent gaming support. 🪟
 - [NoxPlayer](https://bignox.com) - Android emulator optimized for mobile gaming on desktop. 🪟 🍎
+
+[Move to top](#contents)
 
 ## Other Emulators
 
@@ -445,6 +511,8 @@
 - [Mednafen](https://mednafen.github.io) - Multi-system emulator with a focus on precision and compatibility. 🪟 🐧
 - [MelonDS](https://melonds.kuribo64.net) - Nintendo DS emulator with accurate performance and Wi-Fi support. 🪟 🍎 🐧
 - [BSNES](https://bsnes.dev) - SNES emulator with cycle-accurate emulation for high compatibility. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ## Graphics Tools
 
@@ -466,6 +534,8 @@
 - [Pencil2D](https://pencil2d.org) - Simple and intuitive tool for creating 2D hand-drawn animations. 🪟 🍎 🐧
 - [Affinity](https://www.affinity.studio/) - Professional creative suite for photo editing, graphic design, and desktop publishing. 🪟 🍎
 
+[Move to top](#contents)
+
 ## 3D Modeling and Animation
 
 - [Blender](https://blender.org) - 3D creation tool supporting modeling, animation, rendering, video editing, and more. 🪟 🍎 🐧 🟢 ⭐
@@ -474,7 +544,11 @@
 - [OpenSCAD](https://openscad.org) - Script-based 3D CAD modeler for creating precise solid geometry. 🪟 🍎 🐧
 - [Wings 3D](https://www.wings3d.com) - 3D modeling software focusing on subdivision modeling. 🪟 🍎 🐧 🟢
 
+[Move to top](#contents)
+
 ## Security
+
+[Move to top](#contents)
 
 ### Antivirus
 
@@ -484,6 +558,8 @@
 - [ClamAV](https://www.clamav.net) - Antivirus engine for detecting malware, viruses, and other threats. 🪟 🍎 🐧 🟢
 - [Malwarebytes](https://malwarebytes.com) - Malware removal tool offering real-time protection and cleanup. 🪟 🍎
 - [Pareto Security](https://paretosecurity.com/apps) - Check for basic security hygiene of any Windows, Mac or Linux desktop. 🪟 🍎 🐧 [🟢](https://github.com/paretoSecurity/agent)
+
+[Move to top](#contents)
 
 ### Password Managers
 
@@ -496,8 +572,12 @@
 - [RoboForm](https://roboform.com) - Password manager and form filler with multi-platform synchronization. 🪟 🍎 🐧
 - [ProtonPass](https://proton.me/pass) - Free password manager with end-to-end encryption based in Switzerland. 🪟 🍎 🐧 [🟢](https://github.com/protonpass)
 
+[Move to top](#contents)
+
 ### Ad & Tracker Blocking
 
+
+[Move to top](#contents)
 
 ## Image Viewers
 
@@ -506,6 +586,8 @@
 - [JPEGView](https://sourceforge.net/projects/jpegview) - Lean, fast and highly configurable viewer/editor for JPEG, BMP, PNG, WEBP, TGA, GIF and TIFF images. 🪟
 - [qView](https://interversehq.com/qview) - Visually minimal and space efficient. 🪟 🍎 🐧
 - [XnView](https://xnview.com/en) - Image resizer, batch image converter. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ## Remote Access
 
@@ -520,9 +602,13 @@
 - [wmWebStack](https://webstack.wikimint.com) - Local server stack with one-click live publishing and remote device access. 🪟
 - [RemSupp](https://remsupp.com) - Simple remote desktop. 🪟 🍎 🐧
 
+[Move to top](#contents)
+
 ## Video
 
 - [FreeTube](https://freetubeapp.io) - Private YouTube client with no ads. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ### Video Editors
 
@@ -536,6 +622,8 @@
 - [Olive Video Editor](https://olivevideoeditor.org) - Non-linear video editor with powerful features and an intuitive interface. 🪟 🍎 🐧 [🟢](https://github.com/olive-editor/olive)
 - [Avidemux](https://avidemux.sourceforge.net) - Video editor designed for simple cutting, filtering and encoding tasks. 🪟 🍎 🐧 [🟢](https://github.com/mean00/avidemux2)
 - [lossless-cut](https://losslesscut.app) - Swiss army knife of lossless video/audio editing. 🪟 🍎 🐧 [🟢](https://github.com/mifi/lossless-cut)
+
+[Move to top](#contents)
 
 ### Video Players
 
@@ -553,6 +641,8 @@
 - [Videotape](https://usuaia.com/videotape) - Simple and minimalist video player for quick playback of local video files. 🪟
 - [VLC Media Player](https://videolan.org/vlc) - Media player supporting almost all video formats. 🪟 🍎 🐧 🟢
 
+[Move to top](#contents)
+
 ### Video Streaming and Recording
 
 - [OBS Studio](https://obsproject.com) - Software for live streaming and recording video. 🪟 🍎 🐧 🟢 ⭐
@@ -565,6 +655,8 @@
 - [Shadowplay](https://www.nvidia.com/en-ph/geforce/geforce-experience/shadowplay) - Record gameplay videos, screenshots, and livestreams. 🪟
 - [ScreenToGif](https://www.screentogif.com) - Record, edit, and create animated GIFs from your screen. 🪟 [🟢](https://github.com/NickeManarin/ScreenToGif)
 
+[Move to top](#contents)
+
 ### Video Converters and Compressors
 
 - [FFmpeg](https://ffmpeg.org) - Powerful tool for format conversion and multimedia editing. 🪟 🍎 🐧 🟢 ⭐
@@ -576,6 +668,8 @@
 - [XMedia Recode](https://xmedia-recode.de/en) - Multi-format converter with advanced video editing features. 🪟
 - [VidCoder](https://vidcoder.net) - User-friendly HandBrake-based transcoder with batch processing. 🪟 🍎 🟢
 - [Adapter](https://macroplant.com/adapter/video-converter) - Media converter app for video, audio, and images on Mac and Windows. 🪟 🍎
+
+[Move to top](#contents)
 
 ## VPN and Proxy Tools
 
@@ -593,6 +687,8 @@
 - [v2rayN](https://github.com/2dust/v2rayN) - Open source GUI for Xray and Sing-box. 🪟 🍎 🐧 🟢
 - [WireGuard](https://wireguard.com) - Fast, secure VPN protocol designed for simplicity. 🪟 🍎 🐧 [🟢](https://www.wireguard.com/repositories)
 - [Tailscale](https://tailscale.com) - Mesh VPN client for secure private networks using WireGuard. 🪟 🍎 🐧
+
+[Move to top](#contents)
 
 ## Utility
 
@@ -618,6 +714,8 @@
 - [KaiROS AI](https://github.com/avikeid2007/Kairos.local) - Local AI assistant with GPU acceleration and model catalog. 🪟 [🟢](https://github.com/avikeid2007/Kairos.local)
 - [balenaEtcher](https://etcher.balena.io) - Tool for safely flashing OS images to SD cards and USB drives. 🪟 🍎 🐧 [🟢](https://github.com/balena-io/etcher)
 
+[Move to top](#contents)
+
 ### Clipboard Management
 
 - [Beetroot](https://max.nardit.com/beetroot) - Clipboard manager with AI text transforms and OCR extraction. 🪟
@@ -628,6 +726,8 @@
 - [EcoPaste](https://github.com/EcoPasteHub/EcoPaste) - Cross-platform modern clipboard management tool.  🪟 🍎 🐧 🟢
 - [Qopy](https://github.com/0pandadev/qopy) - Minimalist clipboard manager with unique features. 🪟 🍎 🐧 🟢
 
+[Move to top](#contents)
+
 ### Metadata
 
 - [ExifTool](https://exiftool.org) - Command-line tool for editing metadata in various file types. 🪟 🍎 🐧 ⭐
@@ -635,6 +735,8 @@
 - [MP3Tag](https://mp3tag.de/en) - Edit and manage metadata for audio files. 🪟
 - [PhotoME](https://photome.de) - View and edit EXIF metadata for photos. 🪟
 
+
+[Move to top](#contents)
 
 ### Window Management
 
@@ -646,6 +748,8 @@
 - [OnTopReplica](https://github.com/LorenzCK/OnTopReplica) - Display part of a window on top of others. 🪟 🟢
 - [YASB](https://github.com/amnweb/yasb) - Highly configurable Windows status bar. 🪟 🟢
 - [Komorebi](https://github.com/LGUG2Z/komorebi) - Tiling window manager for Windows. 🪟 🟢
+
+[Move to top](#contents)
 
 ### File Management
 
@@ -662,10 +766,14 @@
 - [Sigma File Manager](https://github.com/aleksey-hoffman/sigma-file-manager) - Modern file manager with advanced features. 🪟 🐧 [🟢](https://github.com/aleksey-hoffman/sigma-file-manager)
 - [Cyberduck](https://cyberduck.io) - File transfer client for FTP, SFTP, WebDAV, S3, Azure, OneDrive, and other storage services. 🪟 🍎 [🟢](https://github.com/iterate-ch/cyberduck)
 
+[Move to top](#contents)
+
 ### Application Management
 
 - [Bulk Crap Uninstaller](https://www.bcuninstaller.com) - Powerful tool for uninstalling multiple applications and cleaning leftovers. 🪟 🟢 ⭐
 - [Revo Uninstaller](https://www.revouninstaller.com/revo-uninstaller-free-download) - Advanced uninstaller to remove programs and residual files with free tier. 🪟
+
+[Move to top](#contents)
 
 ### Screenshot
 
@@ -678,6 +786,8 @@
 - [Pixpin](https://pixpin.cn) - Elegant screen capture with an integrated editor. 🪟
 - [Snipaste](https://snipaste.com) - Free, Customizable, Portable snipping tool.
 
+[Move to top](#contents)
+
 ### Space Visualizer
 
 - [WizTree](https://diskanalyzer.com) - Fast disk space analyzer that scans drives and shows file size distribution. 🪟 ⭐
@@ -686,6 +796,8 @@
 - [JDiskReport](https://www.jgoodies.com/freeware/jdiskreport) - Tool for visualizing disk usage with a variety of charts and graphs. 🪟 🐧
 - [SpaceSniffer](http://www.uderzo.it/main_products/space_sniffer) - Identify large files and folders with an intuitive tree map. 🪟
 - [TreeSize Free](https://jam-software.com/treesize_free) - Visualizes disk space usage in a tree-like structure for easy file management. 🪟
+
+[Move to top](#contents)
 
 ### Trackpad
 


### PR DESCRIPTION
## Summary

This PR improves navigation across the curated app lists by adding "Move to top" links after major sections and subsections. The goal is to make long markdown pages easier to browse, especially when jumping between categories.

## Changes

- Added "Move to top" links that point back to the main contents section
- Applied the navigation pattern to the main list and all filtered list variants
- Improved usability for long pages without changing the curated app entries themselves

## Why

The repository’s markdown lists have grown large enough that returning to the contents section requires excessive scrolling. These links make navigation faster and more consistent across the different list views.
