### PR TITLE
Add Trider to Health and Wellness

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -338,6 +338,7 @@
 
 ## Health and Wellness
 
+- [Trider](https://play.google.com/store/apps/details?id=dev.trider.app) - AI habit tracker with journal, mood tracking, Pomodoro timer, and accountability squads. Free, no ads. 🤖
 - [Paula](https://trypaula.com) - Free AI mental health companion using CBT and DBT techniques, with voice sessions, mood tracking, and journaling. 🤖 🍎
 - [Euki](https://eukiapp.org) - Privacy-first period tracker with sexual health resources and local-only data storage. 🤖 🍎 [🟢](https://github.com/Euki-Inc/Euki-Android)
 


### PR DESCRIPTION
## What

Adds [Trider](https://play.google.com/store/apps/details?id=dev.trider.app) to the **Health and Wellness** section of MOBILE.md.

## Why

Trider is a free AI-powered habit tracker for Android:
- AI coach that adapts reminders based on your journal + mood patterns
- Built-in Pomodoro timer
- Journaling + mood tracking
- Accountability squads (3–10 people)
- No ads, no account required to start
- 100+ downloads on Play Store

Fits the Health and Wellness section alongside Paula and Euki.