### PR TITLE
Add igly.ai to Graphics Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,7 @@
 - [Pixen](https://pixenapp.com/mac) - Native pixel art and animation editor designed. 🍎
 - [Affinity](https://www.affinity.studio/) - Professional creative suite for photo editing, graphic design, and desktop publishing. 🪟 🍎
 - [Open Photo AI](https://github.com/vegidio/open-photo-ai) - An open source alternative to the popular photo AI editor. 🪟 🍎 🐧 🟢
+- [igly.ai](https://igly.ai) - AI image editor for background removal, inpainting, upscaling, and generative fill. 🪟 🍎 🐧
 
 ## 3D Modeling and Animation
 


### PR DESCRIPTION
## Summary
- Added igly.ai to the Graphics Tools section.
- igly.ai is a browser-based AI image editor for background removal, inpainting, upscaling, and generative fill.

Demo/reference: https://www.youtube.com/watch?v=HB2E1WZ12is

## Checklist
- [x] Added to README.md only
- [x] Kept the existing list format
- [x] Added to the bottom of the relevant category