### PR TITLE
Add: HealthSync

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -341,6 +341,7 @@
 - [Trider](https://play.google.com/store/apps/details?id=dev.trider.app) - AI habit tracker with journal, mood tracking, Pomodoro timer, and accountability squads. Free, no ads. 🤖
 - [Paula](https://trypaula.com) - Free AI mental health companion using CBT and DBT techniques, with voice sessions, mood tracking, and journaling. 🤖 🍎
 - [Euki](https://eukiapp.org) - Privacy-first period tracker with sexual health resources and local-only data storage. 🤖 🍎 [🟢](https://github.com/Euki-Inc/Euki-Android)
+- [HealthSync](https://healthsync.megabyte.sh/apple-health-app-sync) - Sync selected Apple Health data from HealthKit to a private backend API. 🍎
 
 ## Utility
 


### PR DESCRIPTION
Adds HealthSync to the mobile Health and Wellness section. HealthSync is a free iOS app for syncing selected Apple Health data from HealthKit to a private backend API. Primary project page: https://healthsync.megabyte.sh/apple-health-app-sync