### PR TITLE
Add Snoq to Note Taking

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@
 - [Xournal++](https://xournalpp.github.io) - Take handwritten notes with ease. 🪟 🍎 🐧 [🟢](https://github.com/xournalpp/xournalpp)
 - [RNote](https://rnote.flxzt.net/) - Sketch and take handwritten notes. . 🪟 🍎 🐧 [🟢](https://github.com/flxzt/rnote)
 - [Trilium Notes](https://triliumnotes.org) - Organize your thoughts. Build your personal knowledge base. 🪟 🍎 🐧 [🟢](https://github.com/TriliumNext/Trilium)
+- [Snoq](https://snoq.io) - Secure, offline-first note-taking app with AES-256 encryption. 🪟
 
 ## Text Editors
 


### PR DESCRIPTION
Adds Snoq to the Note Taking section. Snoq is a free, native Windows note-taking app that is offline-first with AES-256 encryption. Listed with the Windows platform badge, consistent with the other proprietary-but-free entries in the section (Obsidian, Notion, Craft).