### PR TITLE
Add: Cate

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@
 - [MDLook](https://mdlook.com) - Portable offline Markdown editor using WebView2 with live preview, dark mode, and diagram support. 🪟
 - [VSCodium](https://vscodium.com) - Community-built VS Code binaries without Microsoft branding, telemetry, or licensing changes. 🪟 🍎 🐧 [🟢](https://github.com/VSCodium/vscodium)
 - [MarkEdit](https://github.com/MarkEdit-app/MarkEdit) - Native Markdown editor for macOS with a TextEdit-like workflow and local-file editing. 🍎 🟢
+- [Cate](https://cate.cero-ai.com) - Code editor on an infinite zoomable canvas where editors, terminals, browsers, and AI agent panels float in a spatial workspace, with docking, detachable windows, and per-project layout persistence. 🪟 🍎 🐧 [🟢](https://github.com/0-AI-UG/cate)
 
 ## Download Managers
 


### PR DESCRIPTION
Adds Cate to the Text Editors section. Cate is a free, open source (MIT) desktop IDE built on an infinite canvas, available for Windows, macOS, and Linux. Added at the bottom of the category per the contribution guidelines.
