### PR TITLE
Add PDF Toolbox to PDF Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@
 - [pdfcpu](https://pdfcpu.io) - A PDF processor written in Go. 🪟 🍎 🐧 [🟢](https://github.com/pdfcpu/pdfcpu)
 - [Stirling-PDF](https://stirling.com) - #1 PDF Application on GitHub that lets you edit PDFs on any device anywhere. 🪟 🍎 🐧 [🟢](https://github.com/Stirling-Tools/Stirling-PDF)
 - [pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit) - PDFtk is a simple tool for doing everyday things with PDF documents. 🪟 🍎 🐧
+- [PDF Toolbox](https://pdftoolbox-three.vercel.app) - Free online PDF tools (compress, merge, split, convert) that process files locally in your browser. No upload needed. 🌐 [🟢](https://github.com/hwlsniper/pdftoolbox)
 
 ## Note Taking
 


### PR DESCRIPTION
## Description

Add [PDF Toolbox](https://pdftoolbox-three.vercel.app) to the **PDF Tools** section under Documents.

PDF Toolbox is a free, open-source, browser-based PDF tool suite:
- Compress, merge, split PDFs
- Convert between PDF ↔ JPG, PDF → Word
- Unlock/protect PDF with passwords
- All processing done client-side — no file uploads needed
- Free, no registration, no daily limits