### PR TITLE
Add Headroom — macOS Claude Code rate-limit monitor (macOS counterpart to WhereMyTokens)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@
 - [TkForge](https://github.com/Axorax/tkforge) - Drag & drop in Figma to create a Python GUI with ease. 🪟 🍎 🐧 🟢 ⭐
 - [WinMerge](https://sourceforge.net/projects/winmerge) - Windows visual diff and merge for files and directories. 🪟 🟢
 - [WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens) - Windows system tray app for monitoring Claude Code token usage in real time. Displays per-session token counts, costs, context window usage, and rate limits. 🪟 [🟢](https://github.com/jeongwookie/WhereMyTokens)
+- [Headroom](https://headroom.walls.sh) - Native macOS menu bar app showing Claude Code's session (5h) and weekly (7d) rate-limit usage as a live %, with color-coded alerts, reset countdowns, context window fill, active model name, and session cost. Zero network calls. 🍎 [🟢](https://github.com/patwalls/headroom)
 - [x64dbg](https://x64dbg.com) - Debugger for Windows. 🪟 🟢
 - [Ghostty](https://ghostty.org) - Fast native terminal emulator with GPU acceleration, tabs, splits, and modern terminal features. 🍎 🐧 [🟢](https://github.com/ghostty-org/ghostty)
 - [iTerm2](https://iterm2.com) - Terminal replacement for macOS with split panes, profiles, search, and extensive customization. 🍎 [🟢](https://github.com/gnachman/iTerm2)


### PR DESCRIPTION
## What

Adds [Headroom](https://headroom.walls.sh) to the **Developer Tools** section, right after WhereMyTokens — which is already listed as the Windows equivalent.

## Why it fits

The list already has [WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens) for Windows (system tray app monitoring Claude Code token usage). Headroom is the macOS counterpart: a native menu bar app that does the same thing, built for macOS.

**What it shows:**
- Session (5h) and weekly (7d) rate-limit usage as a live %
- Context window fill %
- Active model name (Sonnet, Opus, Fable, etc.)
- Session cost in dollars

**Trust story:** Zero network calls — it reads a local file Claude Code's own status line writes to `~/.claude/headroom-usage.json`. No API key, no token, no analytics.

**Details:** Free, MIT, ~267 KB, macOS 13+, Apple Silicon + Intel, signed & notarized.

## Entry added

```markdown
- [Headroom](https://headroom.walls.sh) - Native macOS menu bar app showing Claude Code's session (5h) and weekly (7d) rate-limit usage as a live %, with color-coded alerts, reset countdowns, context window fill, active model name, and session cost. Zero network calls. 🍎 [🟢](https://github.com/patwalls/headroom)
```

Placed immediately after WhereMyTokens since they're the same category of tool (Claude Code usage monitors) for different platforms.