### PR TITLE
Add: LogZero

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -341,6 +341,7 @@
 - [Trider](https://play.google.com/store/apps/details?id=dev.trider.app) - AI habit tracker with journal, mood tracking, Pomodoro timer, and accountability squads. Free, no ads. 🤖
 - [Paula](https://trypaula.com) - Free AI mental health companion using CBT and DBT techniques, with voice sessions, mood tracking, and journaling. 🤖 🍎
 - [Euki](https://eukiapp.org) - Privacy-first period tracker with sexual health resources and local-only data storage. 🤖 🍎 [🟢](https://github.com/Euki-Inc/Euki-Android)
+- [LogZero](https://logzero.app) - Privacy-first habit and health tracker with mood, medication, food, exercise, and weight logs, plus on-device correlation insights. No account, no ads, no trackers. 🍎
 
 ## Utility
 


### PR DESCRIPTION
Add: LogZero

Adds **LogZero** to the **Health and Wellness** section of `MOBILE.md` (iOS), at the bottom of the category as required.

LogZero is an all-in-one private personal life and habit tracker for iOS (iPhone & iPad, iOS 16+). It tracks mood, medication, food (calories + macros), exercise, meditation, weight, and to-dos, with a local statistical correlation engine and a dashboard of streaks and weekly insights. Everything is 100% on-device: no account, no ads, no analytics/telemetry, and zero network requests for user data (App Store privacy label "Data Not Collected"). It fits right next to existing privacy-first trackers like Euki and Paula in this section.

It has a genuine free tier (no trial wall). There is an optional Pro upgrade ($5/mo, $35/yr, or $99 lifetime) that unlocks extra features, but the core app is usable for free, in line with this list's "free apps" scope.

LogZero is closed-source, so I have followed the guideline of omitting the 🟢 open-source icon and used the website as the app-name link.

Entry added:

```
- [LogZero](https://logzero.app) - Privacy-first habit and health tracker with mood, medication, food, exercise, and weight logs, plus on-device correlation insights. No account, no ads, no trackers. 🍎
```

Links:
- Website: https://logzero.app
- App Store: https://apps.apple.com/app/id6773557137

Checklist:
- [x] Added to `MOBILE.md` (mobile app), not `README.md`.
- [x] Placed at the bottom of the existing **Health and Wellness** category.
- [x] Did not reorder any apps.
- [x] Did not modify the table of contents or the `filter` folder (auto-generated).
- [x] Description is concise, highlights features, and ends with a period.
- [x] Description does not start with "A", "An", or "The".
- [x] iOS icon (🍎) used; no 🟢 since the app is closed-source.
