### PR TITLE
Add free Android document apps to PDF Tools

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -228,6 +228,10 @@
 - [Adobe Acrobat Reader](https://www.adobe.com/acrobat/mobile-app.html) - View, annotate, and sign PDFs with advanced tools. 🤖 🍎
 - [Xodo PDF Reader](https://www.xodo.com) - Edit, annotate, and collaborate on PDFs in real time. 🤖 🍎
 - [Foxit PDF Reader](https://www.foxit.com/pdf-reader-mobile) - Lightweight PDF viewer with editing and security tools. 🤖 🍎
+- [Document Reader](https://play.google.com/store/apps/details?id=com.ltsoft.ltdocsviewer) - View PDF, Word, Excel, PowerPoint and text files in one lightweight reader. 🤖
+- [AnyPDF](https://play.google.com/store/apps/details?id=com.mobileups.anypdf) - Fast, ad-light PDF reader and viewer for Android. 🤖
+- [PDF to Word](https://play.google.com/store/apps/details?id=com.mobileups.pdftowordconverter) - Convert PDF documents to editable Word files on-device. 🤖
+- [DocLens Pro](https://play.google.com/store/apps/details?id=com.mobileups.doclenspro) - Scan documents and run OCR to extract text from images and PDFs. 🤖
 
 ## Note Taking
 


### PR DESCRIPTION
Adds four free Android apps to **Documents > PDF Tools** (appended to the bottom of the section, Android 🤖, matching the existing entry format):

- **Document Reader** — view PDF, Word, Excel, PowerPoint and text files in one lightweight reader
- **AnyPDF** — fast, ad-light PDF reader/viewer
- **PDF to Word** — convert PDF to editable Word on-device
- **DocLens Pro** — document scanner + OCR

All are free on Google Play and fit alongside the existing PDF Tools entries. Disclosure: I'm the developer (MobileUps) submitting my own free apps — happy to adjust the descriptions or drop any that aren't a fit.
