### PR TITLE
Add: Pesty

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,7 @@
 - [Parcellite](https://parcellite.sourceforge.io) - Basic clipboard manager. 🐧
 - [Qopy](https://github.com/0pandadev/qopy) - Minimalist clipboard manager with unique features. 🪟 🍎 🐧 🟢
 - [SaneClip](https://saneclip.com) - Clipboard manager that keeps all history local with search and formatting tools. 🍎 [🟢](https://github.com/sane-apps/SaneClip)
+- [Pesty](https://www.moamenbasel.com/pesty/) - Native clipboard manager with a color-coded history strip, pinboards, instant search, and keyboard-driven pasting. 🍎 [🟢](https://github.com/momenbasel/pesty)
 
 ### Metadata
 


### PR DESCRIPTION
## Add: Pesty (clipboard manager, macOS)

Adds **Pesty** to **Utility > Clipboard Management**, alongside the existing macOS managers (Maccy, CopyQ, Clipy).

**Entry added (bottom of the Clipboard Management sub-section):**

```
- [Pesty](https://www.moamenbasel.com/pesty/) - Native clipboard manager with a color-coded history strip, pinboards, instant search, and keyboard-driven pasting. 🍎 [🟢](https://github.com/momenbasel/pesty)
```

**Why it fits this list:**
- Free and open-source (MIT). Install free via Homebrew: `brew install --cask momenbasel/pesty/pesty`, or build from source.
- Native SwiftUI app for macOS - universal binary, Developer ID signed and Apple-notarized.
- Zero third-party dependencies.
- Actively maintained.

**Icons:** 🍎 (macOS) + 🟢 linked to the source repo, matching the existing format used by entries like SaneClip.

**Disclosure for transparency:** a separate paid build is available on the Mac App Store, but this submission links to the free, open-source distribution (landing page + Homebrew + GitHub source), which is what qualifies it as a free app for this list.

- Homepage: https://www.moamenbasel.com/pesty/
- Source: https://github.com/momenbasel/pesty
- License: MIT