### PR TITLE
Add: Nav0

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@
 - [Mullvad Browser](https://mullvad.net/en/download/browser) - Privacy browser with Tor, anti-fingerprinting, and Mullvad VPN. 🪟 🍎 🐧 [🟢](https://github.com/mullvad/mullvad-browser)
 - [Vivaldi](https://vivaldi.com) - Customizable browser putting you in control. 🪟 🍎 🐧
 - [Zen Browser](https://zen-browser.app) - Beautifully designed, privacy-focused browser with custom mods. 🪟 🍎 🐧 [🟢](https://github.com/zen-browser/desktop)
+- [Nav0](https://nav0.org) - Minimal, privacy-focused browser with zero telemetry, tracking, or data collection. 🪟 🍎 🐧 [🟢](https://github.com/nav0-org/nav0-browser)
 
 ## Communication
 


### PR DESCRIPTION
Adds [Nav0](https://nav0.org) to the **Browsers** section (appended to the bottom; TOC untouched).

Nav0 is a free, open-source (MIT), minimal, privacy-focused web browser for Windows, macOS, and Linux — zero telemetry, tracking, or data collection. Repo: https://github.com/nav0-org/nav0-browser

Disclosure: I'm the maintainer.