### PR TITLE
Add Off Grid AI Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,6 +713,7 @@
 - [MonitorControl](https://monitorcontrol.app) - Controls external display brightness, volume, and contrast from macOS keyboard shortcuts and menu bar. 🍎 [🟢](https://github.com/MonitorControl/MonitorControl)
 - [balenaEtcher](https://etcher.balena.io) - Tool for safely flashing OS images to SD cards and USB drives. 🪟 🍎 🐧 [🟢](https://github.com/balena-io/etcher)
 - [Meander](https://everydays.tools/meander) - AI voice-to-text dictation with a free tier: push-to-talk, AI cleanup, and speak-one-language-output-another translation, with native Linux support. 🪟 🐧
+- [Off Grid AI Desktop](https://getoffgridai.co/desktop) - Local AI suite that runs entirely on your Mac: LLM chat, image generation, voice dictation with Whisper, memory and RAG search, clipboard manager, encrypted vault, and MCP connectors, with no account or telemetry. 🍎 [🟢](https://github.com/off-grid-ai/off-grid-ai-desktop)
 
 ### Clipboard Management
 

--- a/README.md
+++ b/README.md
@@ -713,7 +713,7 @@
 - [MonitorControl](https://monitorcontrol.app) - Controls external display brightness, volume, and contrast from macOS keyboard shortcuts and menu bar. 🍎 [🟢](https://github.com/MonitorControl/MonitorControl)
 - [balenaEtcher](https://etcher.balena.io) - Tool for safely flashing OS images to SD cards and USB drives. 🪟 🍎 🐧 [🟢](https://github.com/balena-io/etcher)
 - [Meander](https://everydays.tools/meander) - AI voice-to-text dictation with a free tier: push-to-talk, AI cleanup, and speak-one-language-output-another translation, with native Linux support. 🪟 🐧
-- [Off Grid AI Desktop](https://getoffgridai.co/desktop) - Local AI suite that runs entirely on your Mac: LLM chat, image generation, voice dictation with Whisper, memory and RAG search, clipboard manager, encrypted vault, and MCP connectors, with no account or telemetry. 🍎 [🟢](https://github.com/off-grid-ai/off-grid-ai-desktop)
+- [Off Grid AI Desktop](https://getoffgridai.co/desktop) - Local AI suite for Mac: chat, image generation, dictation, and memory search, all on-device with no account. 🍎 [🟢](https://github.com/off-grid-ai/off-grid-ai-desktop)
 
 ### Clipboard Management
 


### PR DESCRIPTION
Adds Off Grid AI Desktop to the Utility section, alongside the other local-AI apps (KaiROS AI, Saga Reader, Whisper by Remskill).

Off Grid AI Desktop is a free, open-source (AGPL-3.0) macOS app that runs a local AI suite entirely on your Mac: LLM chat (llama.cpp), on-device image generation, voice dictation and transcription (Whisper), personal memory and RAG search, clipboard manager, encrypted vault, and MCP connectors. No account, no telemetry, no cloud.

- Website: https://getoffgridai.co/desktop
- Source: https://github.com/off-grid-ai/off-grid-ai-desktop
- License: AGPL-3.0

Entry added to the bottom of the category per the contributing guide, name links to the website, and the open-source icon links to the repository.

Disclosure: I'm involved with the project.