### PR TITLE
Add Burrete

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,6 +713,7 @@
 - [MonitorControl](https://monitorcontrol.app) - Controls external display brightness, volume, and contrast from macOS keyboard shortcuts and menu bar. 🍎 [🟢](https://github.com/MonitorControl/MonitorControl)
 - [balenaEtcher](https://etcher.balena.io) - Tool for safely flashing OS images to SD cards and USB drives. 🪟 🍎 🐧 [🟢](https://github.com/balena-io/etcher)
 - [Meander](https://everydays.tools/meander) - AI voice-to-text dictation with a free tier: push-to-talk, AI cleanup, and speak-one-language-output-another translation, with native Linux support. 🪟 🐧
+- [Burrete](https://burrete-landing.vercel.app) - Molecular file workspace with Finder Quick Look previews, Mol* 3D, and chemistry grids. 🍎 [🟢](https://github.com/SergeiNikolenko/Burrete)
 
 ### Clipboard Management
 


### PR DESCRIPTION
Adds Burrete at the bottom of the Utility category following the contribution guide. It is a free, open-source macOS molecular-file workspace with Finder Quick Look previews.\n\nDisclosure: I am the author and maintainer of Burrete.