### PR TITLE
Add: Knopo

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@
 - [RNote](https://rnote.flxzt.net/) - Sketch and take handwritten notes. . 🪟 🍎 🐧 [🟢](https://github.com/flxzt/rnote)
 - [Trilium Notes](https://triliumnotes.org) - Organize your thoughts. Build your personal knowledge base. 🪟 🍎 🐧 [🟢](https://github.com/TriliumNext/Trilium)
 - [Snoq](https://snoq.io) - Secure, offline-first note-taking app with AES-256 encryption. 🪟
+- [Knopo](https://github.com/alkalim/Knopo) - Local-first outliner for plain Markdown notes with backlinks, page/block references, and graph-friendly files. 🍎 [🟢](https://github.com/alkalim/Knopo)
 
 ## Text Editors
 


### PR DESCRIPTION
Adds Knopo to the Note Taking category.

Knopo is a free, open-source macOS outliner for plain Markdown notes with backlinks, page/block references, and graph-friendly files.