### PR TITLE
Add: Moni Proxy

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -197,6 +197,7 @@
 - [PingTools](https://pingtools.org) - Includes ping, traceroute, port scanner, and more for network diagnostics. 🤖
 - [Network Analyzer](https://apps.apple.com/us/app/network-analyzer/id562315041) - Diagnose Wi-Fi and network problems with detailed insights. 🍎
 - [NetMonster](https://play.google.com/store/apps/details?id=cz.mroczis.netmonster) - Displays detailed information about cellular networks. 🤖
+- [Moni Proxy](https://moniproxy.com) - Capture, inspect, mock, and replay HTTPS API traffic directly on your device. 🤖 🍎
 
 ### Game Engines
 


### PR DESCRIPTION
Adds **Moni Proxy** to the Developer Tools → Network Analysis category in MOBILE.md.

Moni Proxy is a mobile-first HTTP/HTTPS debugging proxy that captures, inspects, mocks, and replays API traffic directly on iOS and Android — no computer, no jailbreak, no root. It has a permanent free tier.

- Website: https://moniproxy.com
- iOS: https://apps.apple.com/us/app/moni-proxy-https-debug/id6772754819
- Android: https://play.google.com/store/apps/details?id=com.moni.proxy

Entry added at the bottom of the **Network Analysis** category, following the `- [Name](URL) - Description.` format with 🤖 🍎 platform icons and a description ending in a period. One app per PR; no changes to the table of contents or the filter folder.