### PR TITLE
Add: Timeline Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,7 @@
 - [Olive Video Editor](https://olivevideoeditor.org) - Non-linear video editor with powerful features and an intuitive interface. 🪟 🍎 🐧 [🟢](https://github.com/olive-editor/olive)
 - [Avidemux](https://avidemux.sourceforge.net) - Video editor designed for simple cutting, filtering and encoding tasks. 🪟 🍎 🐧 [🟢](https://github.com/mean00/avidemux2)
 - [lossless-cut](https://losslesscut.app) - Swiss army knife of lossless video/audio editing. 🪟 🍎 🐧 [🟢](https://github.com/mifi/lossless-cut)
+- [Timeline Studio](https://video-editor.ai-creator.top/) - Local-first browser video editor with automatic captions, AI voiceovers, multi-track editing, and MP4/WebM export. [🟢](https://github.com/MartinDelophy/ai-video-editor)
 
 ### Video Players
 


### PR DESCRIPTION
## What changed

- Added Timeline Studio to the Video Editors category.
- Linked the app name to its browser editor and the open-source icon to its GitHub repository.

## Why

Timeline Studio is a free, local-first browser video editor with automatic captions, AI voiceovers, multi-track editing, and MP4/WebM export.

## Validation

- Confirmed the app and source links return successfully.
- Ran `git diff --check`.
- Verified the entry follows the repository's contribution format and is appended to the category.
