### PR TITLE
Add: echo99

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@
 - [Audacity](https://audacityteam.org/download) - Audio editor for recording and editing sounds. 🪟 🍎 🐧 🟢 ⭐
 - [Ocenaudio](https://ocenaudio.com) - Easy-to-use audio editor for recording and analyzing sounds. 🪟 🍎 🐧
 - [Wavosaur](https://www.wavosaur.com) - Simple audio editor for recording, editing, and processing sound. 🪟
+- [echo99](https://www.echo99.app/) - Private call recorder with on-device transcription and speaker labels. 🍎
 
 ### DJ Software
 


### PR DESCRIPTION
## What changed

- Added echo99 to the Audio Recording section.
- Marked it as available for macOS.

## Why

echo99 is a free Mac call recorder with on-device transcription and speaker labels.

## Validation

- Confirmed there is no existing echo99 issue or pull request.
- Confirmed the official product page supports the description and free status.
- Confirmed only `README.md` changed.
- Ran `git diff --check`.
