### PR TITLE
Add: PayDance

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,6 +720,7 @@
 - [Burrete](https://burrete-landing.vercel.app) - Molecular file workspace with Finder Quick Look previews, Mol* 3D, and chemistry grids. 🍎 [🟢](https://github.com/SergeiNikolenko/Burrete)
 - [Off Grid AI Desktop](https://getoffgridai.co/desktop) - Local AI suite for Mac: chat, image generation, dictation, and memory search, all on-device with no account. 🍎 [🟢](https://github.com/off-grid-ai/off-grid-ai-desktop)
 - [Core-Monitor](https://offyotto.github.io/Core-Monitor/) - Apple Silicon system monitor showing CPU, GPU, memory, battery, power, temperatures, storage, and fan data with optional fan control. 🍎 [🟢](https://github.com/offyotto/Core-Monitor)
+- [PayDance](https://paydance.vercel.app/en/) - Shows earnings growing every second based on monthly, daily, or hourly pay, with custom workdays, breaks, overnight shifts, and a compact mini mode. 🪟 [🟢](https://github.com/MrBaoboer/PayDance)
 
 ### Clipboard Management
 

--- a/README.md
+++ b/README.md
@@ -720,7 +720,7 @@
 - [Burrete](https://burrete-landing.vercel.app) - Molecular file workspace with Finder Quick Look previews, Mol* 3D, and chemistry grids. 🍎 [🟢](https://github.com/SergeiNikolenko/Burrete)
 - [Off Grid AI Desktop](https://getoffgridai.co/desktop) - Local AI suite for Mac: chat, image generation, dictation, and memory search, all on-device with no account. 🍎 [🟢](https://github.com/off-grid-ai/off-grid-ai-desktop)
 - [Core-Monitor](https://offyotto.github.io/Core-Monitor/) - Apple Silicon system monitor showing CPU, GPU, memory, battery, power, temperatures, storage, and fan data with optional fan control. 🍎 [🟢](https://github.com/offyotto/Core-Monitor)
-- [PayDance](https://paydance.vercel.app/en/) - Real-time wage app that calculates earnings second by second from your salary and work schedule, making the value of your time visible. 🪟 [🟢](https://github.com/MrBaoboer/PayDance)
+- [PayDance](https://paydance.vercel.app/en/) - Real-time wage app that shows your earnings ticking up second by second. Set your salary and work hours, then see the value of your time at a glance. 🪟 [🟢](https://github.com/MrBaoboer/PayDance)
 
 ### Clipboard Management
 

--- a/README.md
+++ b/README.md
@@ -720,7 +720,7 @@
 - [Burrete](https://burrete-landing.vercel.app) - Molecular file workspace with Finder Quick Look previews, Mol* 3D, and chemistry grids. 🍎 [🟢](https://github.com/SergeiNikolenko/Burrete)
 - [Off Grid AI Desktop](https://getoffgridai.co/desktop) - Local AI suite for Mac: chat, image generation, dictation, and memory search, all on-device with no account. 🍎 [🟢](https://github.com/off-grid-ai/off-grid-ai-desktop)
 - [Core-Monitor](https://offyotto.github.io/Core-Monitor/) - Apple Silicon system monitor showing CPU, GPU, memory, battery, power, temperatures, storage, and fan data with optional fan control. 🍎 [🟢](https://github.com/offyotto/Core-Monitor)
-- [PayDance](https://paydance.vercel.app/en/) - Shows earnings growing every second based on monthly, daily, or hourly pay, with custom workdays, breaks, overnight shifts, and a compact mini mode. 🪟 [🟢](https://github.com/MrBaoboer/PayDance)
+- [PayDance](https://paydance.vercel.app/en/) - Real-time wage app that calculates earnings second by second from your salary and work schedule, making the value of your time visible. 🪟 [🟢](https://github.com/MrBaoboer/PayDance)
 
 ### Clipboard Management
 


### PR DESCRIPTION
## Summary

- Add PayDance to the Utility section.
- Link the app name to the English website and the open-source icon to its GitHub repository.
- Mark PayDance as available on Windows and open source.

## Why

PayDance is a real-time wage app that shows earnings ticking up second by second. Users set their salary and work hours, then see the value of their time at a glance.

Closes #194

## Validation

- Confirmed that the change only adds one entry to `README.md`.
- Confirmed that the entry is at the end of the Utility section.
- Confirmed that the English website returns HTTP 200.
- Confirmed that the source repository is reachable.
- Ran `git diff --check`.
