### PR TITLE
Add PDFluent to PDF Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@
 - [pdfcpu](https://pdfcpu.io) - A PDF processor written in Go. 🪟 🍎 🐧 [🟢](https://github.com/pdfcpu/pdfcpu)
 - [Stirling-PDF](https://stirling.com) - #1 PDF Application on GitHub that lets you edit PDFs on any device anywhere. 🪟 🍎 🐧 [🟢](https://github.com/Stirling-Tools/Stirling-PDF)
 - [pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit) - PDFtk is a simple tool for doing everyday things with PDF documents. 🪟 🍎 🐧
+- [PDFluent](https://pdfluent.com/download/) - Offline PDF editor for forms, OCR, redaction, signatures, conversion, and page management on Windows and macOS. 🪟 🍎
 
 ## Note Taking
 


### PR DESCRIPTION
Disclosure: I maintain PDFluent.

Adding PDFluent to PDF Tools — a free, offline desktop PDF editor for Windows and macOS (forms, OCR, redaction, signatures, conversion, page management). Added at the end of the section per the "do not reorder" convention.

I checked the contribution guidelines and searched for an existing PDFluent entry (none found).
