### PR TITLE
Add: FluxDown

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -262,6 +262,7 @@
 - [ADM (Advanced Download Manager)](https://play.google.com/store/apps/details?id=com.dv.adm) - Powerful download manager with split download support. 🤖
 - [iDownloader](https://apps.apple.com/us/app/idownloader-pro/id657087236) - Download manager with browser integration and video support. 🍎
 - [MyJDownloader](https://my.jdownloader.org) - Remotely manage downloads from your desktop JDownloader. 🤖 🍎
+- [FluxDown](https://fluxdown.zerx.dev) - Multi-protocol download manager with IDM-style dynamic segmentation, covering HTTP, FTP, BitTorrent, eD2K, HLS and DASH. 🤖 [🟢](https://github.com/zerx-lab/FluxDown)
 
 ## Graphics Tools
 

--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@
 - [Persepolis Download Manager](https://persepolisdm.github.io) - GUI for Aria2, providing an intuitive interface. 🪟 🍎 🐧 [🟢](https://github.com/persepolisdm/persepolis)
 - [Xtreme Download Manager (XDM)](https://xtremedownloadmanager.com) - Powerful tool to increase download speed. 🪟 🍎 🐧 [🟢](https://github.com/subhra74/xdm)
 - [Transmission](https://transmissionbt.com) - Lightweight BitTorrent client with native desktop, daemon, and web interfaces. 🪟 🍎 🐧 [🟢](https://github.com/transmission/transmission)
+- [FluxDown](https://fluxdown.zerx.dev) - Multi-protocol download manager with IDM-style dynamic segmentation, covering HTTP, FTP, BitTorrent, eD2K, HLS and DASH. 🪟 🍎 🐧 [🟢](https://github.com/zerx-lab/FluxDown)
 
 ## Games
 


### PR DESCRIPTION
Adding FluxDown to Download Managers (README.md for desktop, MOBILE.md for Android).

It is a free and open-source (AGPL-3.0) multi-protocol download manager written in Rust + Tokio with a Flutter UI. It handles HTTP/HTTPS, FTP, BitTorrent magnets, eD2K/Kad, HLS and DASH in one queue, and does IDM-style dynamic segmentation — the remaining range keeps getting split among idle connections while the download runs, so a single slow mirror does not hold up the tail of a transfer.

Website: https://fluxdown.zerx.dev
Repo: https://github.com/zerx-lab/FluxDown

Both entries were appended to the bottom of their category, no reordering, and the TOC and filter/ folder were left untouched.