### PR TITLE
Add: PDF Mavericks

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@
 - [Stirling-PDF](https://stirling.com) - #1 PDF Application on GitHub that lets you edit PDFs on any device anywhere. 🪟 🍎 🐧 [🟢](https://github.com/Stirling-Tools/Stirling-PDF)
 - [pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit) - PDFtk is a simple tool for doing everyday things with PDF documents. 🪟 🍎 🐧
 - [PDFluent](https://pdfluent.com/download/) - Offline PDF editor for forms, OCR, redaction, signatures, conversion, and page management on Windows and macOS. 🪟 🍎
+- [PDF Mavericks](https://www.pdfmavericks.com) - Compress, merge, split, sign, convert and add passwords to PDFs entirely in the browser, with no upload and no account. 🪟 🍎 🐧
 
 ## Note Taking
 


### PR DESCRIPTION
Adds [PDF Mavericks](https://www.pdfmavericks.com) to the bottom of PDF Tools.

It is a free, no-account PDF toolkit that runs entirely in the browser — compress, merge, split, sign, convert and password-protect. Processing happens in JavaScript/wasm on the device, so files are never uploaded to a server. Works on Windows, macOS and Linux in any modern browser.

Disclosure: I work on this project. It is not open source, so no 🟢 icon.

Happy to adjust the entry text or move it if another section fits better.
