### PR TITLE
Add: Waindow

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,6 +764,7 @@
 - [Komorebi](https://github.com/LGUG2Z/komorebi) - Tiling window manager for Windows. 🪟 🟢
 - [Niri](https://github.com/niri-wm/niri) - Scrollable-tiling Wayland compositor written in Rust. 🐧 🟢
 - [AltTab](https://alt-tab.app) - Window switcher that brings Windows-style alt-tab previews and controls to macOS. 🍎 [🟢](https://github.com/lwouis/alt-tab-macos)
+- [Waindow](https://www.waindow.app/) - Arranges and restores Mac windows, links local Markdown memos to them, captures long pages, and prevents idle sleep. 🍎
 
 ### File Management
 


### PR DESCRIPTION
## Summary

Adds Waindow to the Window Management category. Waindow is a free macOS utility for arranging and restoring windows, window-linked local Markdown memos, long-page capture, and Keep Awake.

## Checks

- Added at the bottom of the existing category
- Description is concise and ends with a period
- Marked macOS-only with the Apple icon
- Changed only one README line; no generated filter or table-of-contents files were edited