### PR TITLE
Add: Torto

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@
 - [Sigil](https://sigil-ebook.com) - EPUB editor. 🪟 🍎 🐧 [🟢](https://github.com/Sigil-Ebook/Sigil)
 - [Simple Comic](https://apps.apple.com/us/app/simple-comic/id1497435571?mt=12) - Reader for PDF, CBZ, and CBR formats. 🍎
 - [KOReader](https://koreader.rocks) - KOReader is a document viewer for E Ink devices. 🐧 [🟢](https://github.com/koreader/koreader)
+- [Torto](https://github.com/L-Chris/torto) - Native local-first e-book reader for Windows and macOS with two-page reading, highlights, translation, AI assistance, WebDAV sync, and no WebView. 🪟 🍎 [🟢](https://github.com/L-Chris/torto)
 
 ### PDF Tools
 


### PR DESCRIPTION
## What changed

Adds [Torto](https://github.com/L-Chris/torto) to the desktop **E-book** section.

## Why

Torto is a free and open-source, local-first ebook reader for Windows and macOS. It provides native two-page reading, search, highlights, optional translation and AI assistance, direct WebDAV sync, and does not use a WebView for book rendering.

## Checks

- Added one entry at the bottom of the existing category
- Used the documented Windows, macOS, and open-source markers
- Linked to a public MIT-licensed repository with current Windows and macOS releases