### PR TITLE
Add: ItsPaint

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@
 - [Pixen](https://pixenapp.com/mac) - Native pixel art and animation editor designed. 🍎
 - [Affinity](https://www.affinity.studio/) - Professional creative suite for photo editing, graphic design, and desktop publishing. 🪟 🍎
 - [Open Photo AI](https://github.com/vegidio/open-photo-ai) - An open source alternative to the popular photo AI editor. 🪟 🍎 🐧 🟢
+- [ItsPaint](https://itspaintmac.com/) - MS Paint for macOS: blank canvas at any size, paste one image onto another, crop, and mark up screenshots. 🍎 🟢
 
 ## 3D Modeling and Animation
 


### PR DESCRIPTION
Adds **ItsPaint** to Graphics Tools.

- Site: https://itspaintmac.com/
- Source (MIT): https://github.com/joshlin2201/itspaint
- Mac App Store (free): https://apps.apple.com/us/app/itspaint/id6796493980?mt=12

macOS has never shipped a Paint. Preview annotates an image you already have but won't create a blank one, and Paintbrush is Windows-only in this list's current entry. ItsPaint is a native Swift 6 app that does the blank canvas, paste-one-image-onto-another, crop, and screenshot markup (numbered step badges, pixelate redaction).

Free, MIT, no account, no telemetry and no network code at all — the README carries three commands that verify that against the shipped build.

Added to the bottom of Graphics Tools per contributing.md, description ends with a period, TOC and filter/ untouched (auto-generated), commit message is `Add: ItsPaint`.