### PR TITLE
Add: Push or Pay

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -348,6 +348,7 @@
 - [Paula](https://trypaula.com) - Free AI mental health companion using CBT and DBT techniques, with voice sessions, mood tracking, and journaling. 🤖 🍎
 - [Euki](https://eukiapp.org) - Privacy-first period tracker with sexual health resources and local-only data storage. 🤖 🍎 [🟢](https://github.com/Euki-Inc/Euki-Android)
 - [LogZero](https://logzero.app) - Privacy-first habit and health tracker with mood, medication, food, exercise, and weight logs, plus on-device correlation insights. No account, no ads, no trackers. 🍎
+- [Push or Pay](https://pushorpay.netlify.app) - Free accountability game for two: protect a daily habit streak or your partner collects a playful "Lazy Tax" and gets to cheer or tease you. No sign-up, no ads. 🤖 🍎
 
 ## Utility
 


### PR DESCRIPTION
Adds Push or Pay to Health and Wellness in MOBILE.md.

[Push or Pay](https://pushorpay.netlify.app) is a free, no-signup, no-ads accountability game for two: you protect a daily habit streak (e.g. push-ups), and if you skip, your partner collects a playful "Lazy Tax" and gets to cheer or tease you. Works as an installable PWA on both Android and iOS (Add to Home Screen).

Fits alongside the existing Trider/Euki/LogZero habit-and-accountability entries in that section. Followed contributing.md: only touched MOBILE.md, added to the bottom of the existing category, concise description ending in a period, correct platform emoji tags.