### PR TITLE
Add: Nexus Shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@
 - [WezTerm](https://wezterm.org) - GPU-accelerated terminal emulator and multiplexer with tabs, panes, SSH, and Lua configuration. 🪟 🍎 🐧 [🟢](https://github.com/wezterm/wezterm)
 - [Tura](https://turaai.net/) - Local-first AI coding agent with persistent parallel sessions, desktop and terminal interfaces, and local-model support. 🪟 🍎 🐧 [🟢](https://github.com/Tura-AI/tura)
 - [DevProjex](https://github.com/Avazbek22/DevProjex) - Build structured, token-counted project context with visual file selection, Smart Ignore, preview, and multiple output formats.    🪟 🍎 🐧 [🟢](https://github.com/Avazbek22/DevProjex)
+- [Nexus Shell](https://nexusshell.app/?utm_source=github&utm_medium=directory&utm_campaign=awesome-free-apps) - Native macOS SSH workspace with multi-tab terminals, dual-pane file transfer, server monitoring, and Docker controls. 🍎
 
 ### API Development
 


### PR DESCRIPTION
## Summary

- Add Nexus Shell to the Developer Tools section.
- Use the project website and the repository's concise description format.

## Why it fits

Nexus Shell is a native macOS SSH workspace for Apple silicon Macs. Its basic personal SSH functionality is permanently free; optional Pro features are available separately. The list already includes terminal and SSH tools in this section, including WezTerm, iTerm2, and Ghostty.

## Disclosure

I am the developer of Nexus Shell and am submitting it transparently for maintainer review.