### PR TITLE
Add SproutGuard to mobile Health and Wellness

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -349,6 +349,7 @@
 - [Paula](https://trypaula.com) - Free AI mental health companion using CBT and DBT techniques, with voice sessions, mood tracking, and journaling. 🤖 🍎
 - [Euki](https://eukiapp.org) - Privacy-first period tracker with sexual health resources and local-only data storage. 🤖 🍎 [🟢](https://github.com/Euki-Inc/Euki-Android)
 - [LogZero](https://logzero.app) - Privacy-first habit and health tracker with mood, medication, food, exercise, and weight logs, plus on-device correlation insights. No account, no ads, no trackers. 🍎
+- [SproutGuard](https://apps.apple.com/us/app/sproutguard-screen-time-detox/id6768664921) - Screen time blocker for adults using Apple Screen Time, with scheduled blocks, loophole-resistant website blocking, and no account or cloud. 🍎
 
 ## Utility
 


### PR DESCRIPTION
## Summary
- add SproutGuard to `MOBILE.md` under `Health and Wellness`

## Why it fits
SproutGuard is a free iPhone app for adults who want to cut screen time and block distracting apps/sites using Apple's built-in Screen Time controls. It fits this section alongside habit and well-being tools.

Developer disclosure: I'm the developer of SproutGuard.
