### PR TITLE
Add: DueFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,6 +728,7 @@
 - [Off Grid AI Desktop](https://getoffgridai.co/desktop) - Local AI suite for Mac: chat, image generation, dictation, and memory search, all on-device with no account. 🍎 [🟢](https://github.com/off-grid-ai/off-grid-ai-desktop)
 - [Core-Monitor](https://offyotto.github.io/Core-Monitor/) - Apple Silicon system monitor showing CPU, GPU, memory, battery, power, temperatures, storage, and fan data with optional fan control. 🍎 [🟢](https://github.com/offyotto/Core-Monitor)
 - [AI Dictation](https://aidictation.com) - Voice-to-text with configurable shortcuts, offline recognition on supported devices, and optional cloud transcription and cleanup. 🪟 🍎 [🟢](https://github.com/writingmate/aidictation)
+- [DueFlow](https://ustinian5.github.io/DueFlow/) - Local-first deadline planner that turns notes or OCR text into reverse schedules, checks risks, and exports calendar events. 🍎 [🟢](https://github.com/Ustinian5/DueFlow)
 
 ### Clipboard Management
 


### PR DESCRIPTION
## Summary

- add DueFlow to the bottom of the Utility category
- mark it as a free, open-source macOS app
- link the app name to its GitHub Pages site and the source icon to its repository

## Why it fits

DueFlow is a local-first deadline planner for macOS. It turns notes or OCR text into reverse schedules, checks plan risks, and exports calendar events. The project is MIT-licensed and provides downloadable Apple Silicon and Intel releases.

## Validation

- repository and project site return HTTP 200
- entry follows the contribution format and description rules
- `node --check index.js` passes
- generated macOS-only and open-source-only filters each include DueFlow once
- `git diff --check` passes