### PR TITLE
Add: Atomic Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@
 - [Tura](https://turaai.net/) - Build agent that uses 80% less token and delivers better results. 🪟 🍎 🐧 [🟢](https://github.com/Tura-AI/tura)
 - [DevProjex](https://github.com/Avazbek22/DevProjex) - Build structured, token-counted project context with visual file selection, Smart Ignore, preview, and multiple output formats.    🪟 🍎 🐧 [🟢](https://github.com/Avazbek22/DevProjex)
 - [Nexus Shell](https://nexusshell.app/?utm_source=github&utm_medium=directory&utm_campaign=awesome-free-apps) - Native macOS SSH workspace with multi-tab terminals, dual-pane file transfer, server monitoring, and Docker controls. 🍎
+- [Atomic Agent](https://atomicagent.io) - Local-first CLI and TUI coding assistant that runs open-weight models entirely on your machine. Includes 56 built-in tools for browser, filesystem, git, memory, and vision, MCP support, and a five-layer local memory system. No account or API key required. 🪟 🍎 🐧 [🟢](https://github.com/AtomicBot-ai/atomic-agent)
 
 ### API Development
 


### PR DESCRIPTION
## Summary

Hi! I'm the CPO of Atomic Agent. Thanks for this great list, our team would be thrilled if you added us.

Adds **Atomic Agent** to the bottom of the Developer Tools section, one line in `README.md`.

- Site: https://atomicagent.io
- Docs: https://atomicagent.io/docs
- Source (MIT): https://github.com/AtomicBot-ai/atomic-agent
- Install: `curl -fsSL https://atomicagent.io/install | sh`

## Why it fits

Atomic Agent is a local-first CLI and TUI coding assistant. It runs open-weight models entirely on your machine through a llama.cpp fork, so there is no account or API key required to install and run it. It ships 56 built-in tools (browser, filesystem, git, memory, vision), supports MCP, and has a five-layer local memory system. The TUI is built on React and ink. macOS, Linux, and Windows.

It is free and MIT licensed, which is the core criterion for this list. The Developer Tools section already covers this neighbourhood well, with Ollama for running local models and Agent Island and Tura for AI coding agents, so a local-first agent that runs the models itself sits naturally alongside them.

One note in the interest of full transparency: the repo is about 4 months old. It is active and maintained (~2k stars) by the AtomicBot-ai organization, which ships several established projects.

## Guidelines followed

- Added to the **bottom** of the Developer Tools category, existing order untouched.
- Description is concise, does not start with "A"/"An"/"The", and ends with a period.
- Platform icons after the description, with 🟢 linked to the source repository since the app is open-source and has a separate website.
- Table of contents and the `filter/` folder untouched (auto-generated).
- Commit message: `Add: Atomic Agent`.

## Disclosure

I work on Atomic Agent and am submitting it transparently for maintainer review. Happy to adjust the wording, the icons, or the placement if you'd prefer something different.
