### PR TITLE
Add: OffPDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@
 - [Stirling-PDF](https://stirling.com) - #1 PDF Application on GitHub that lets you edit PDFs on any device anywhere. 🪟 🍎 🐧 [🟢](https://github.com/Stirling-Tools/Stirling-PDF)
 - [pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit) - PDFtk is a simple tool for doing everyday things with PDF documents. 🪟 🍎 🐧
 - [PDFluent](https://pdfluent.com/download/) - Offline PDF editor for forms, OCR, redaction, signatures, conversion, and page management on Windows and macOS. 🪟 🍎
+- [OffPDF](https://offpdf.com) - Private, offline PDF toolbox for organizing, converting, compressing, OCR, and more. 🪟 🍎 [🟢](https://github.com/McanKul/offpdf)
 
 ## Note Taking
 


### PR DESCRIPTION
## Summary

Adds [OffPDF](https://offpdf.com) to the bottom of **Documents → PDF Tools**.

## Why it fits

OffPDF is a free, MIT-licensed desktop toolbox with 22 PDF workflows. It organizes, converts, compresses, OCRs, protects, and repairs documents locally, with no uploads, account, or telemetry. Published releases are available for Windows x64 and Apple Silicon macOS.

## Checks

- Changed only README.md.
- Added the entry at the bottom of the existing category.
- Kept the generated table of contents and filter files unchanged.
- Used the documented Windows, macOS, and linked open-source markers.
- Verified the website and source links.

## Disclosure

I maintain OffPDF and am submitting it transparently for maintainer review.