### PR TITLE
Add: MacOSCleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,6 +728,7 @@
 - [Off Grid AI Desktop](https://getoffgridai.co/desktop) - Local AI suite for Mac: chat, image generation, dictation, and memory search, all on-device with no account. 🍎 [🟢](https://github.com/off-grid-ai/off-grid-ai-desktop)
 - [Core-Monitor](https://offyotto.github.io/Core-Monitor/) - Apple Silicon system monitor showing CPU, GPU, memory, battery, power, temperatures, storage, and fan data with optional fan control. 🍎 [🟢](https://github.com/offyotto/Core-Monitor)
 - [AI Dictation](https://aidictation.com) - Voice-to-text with configurable shortcuts, offline recognition on supported devices, and optional cloud transcription and cleanup. 🪟 🍎 [🟢](https://github.com/writingmate/aidictation)
+- [MacOSCleaner](https://github.com/AlexTkDev/MacOSCleaner) - macOS utility for cleaning caches, temporary files, app leftovers, and duplicate files, with disk analysis and app uninstallation. 🍎 🟢
 
 ### Clipboard Management
 


### PR DESCRIPTION
Add MacOSCleaner to the Utility section.

MacOSCleaner is a free, open-source macOS utility for cleaning caches, temporary files, app leftovers, and duplicate files, with disk analysis and app uninstallation.

Project: https://github.com/AlexTkDev/MacOSCleaner
Site: https://alextkdev.github.io/MacOSCleaner/