### PR TITLE
Add: Holeberry

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,7 @@
 ### Ad & Tracker Blocking
 
 - [SaneHosts](https://sanehosts.com) - macOS hosts file manager for system-wide ad and tracker blocking. 🍎 [🟢](https://github.com/sane-apps/SaneHosts)
+- [Holeberry](https://holeberryapp.com) - Native macOS menu bar app to monitor and control Pi-hole instances with blocking stats, timed disable, and one-click unblocking. 🍎 [🟢](https://github.com/pedrovieira/Holeberry)
 
 ## Image Viewers
 


### PR DESCRIPTION
## Summary

Adds [Holeberry](https://github.com/pedrovieira/Holeberry) to the bottom of **Security → Ad & Tracker Blocking**.

## Why it fits

Holeberry is a native macOS menu bar app to monitor and control Pi-hole® instances. Pi-hole is the most widely used self-hosted, DNS-level ad and tracker blocker, and Holeberry brings its day-to-day controls to the menu bar: live blocking status and query stats, disabling blocking for a set time or indefinitely, allowlisting/unblocking recently blocked domains, and one-click unblocking of the domain in your current browser tab. It supports Pi-hole v6 and v5, multiple instances, and global keyboard shortcuts.

The **Ad & Tracker Blocking** subcategory is the natural home.

## Checks

- Changed only `README.md`.
- Added the entry at the bottom of the existing category.
- Kept the generated table of contents and filter files unchanged.
- Used the documented macOS (🍎) and linked open-source (🟢) markers.
- Verified the website and source links (both return 200).

## Disclosure

I maintain Holeberry and am submitting it transparently for maintainer review.