### PR TITLE
Add nowbar to System Customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@
 - [SaneBar](https://sanebar.com) - Menu bar icon manager and organizer. Local-only alternative to Bartender. 🍎 [🟢](https://github.com/sane-apps/SaneBar)
 - [SaneClick](https://saneclick.com) - Finder toolbar customizer for adding quick actions. 🍎 [🟢](https://github.com/sane-apps/SaneClick)
 - [Thaw](https://github.com/stonerl/Thaw) - Menu bar manager for hiding, arranging, and customizing menu bar items. 🍎 [🟢](https://github.com/stonerl/Thaw)
+- [nowbar](https://apps.apple.com/us/app/nowbar-album-art-menu-bar/id6798459887) - Live album art for the currently playing music, right in the menu bar. 🍎 [🟢](https://github.com/arian-shamaei/nowbar)
 
 ### Wallpaper Tools
 


### PR DESCRIPTION
Adds [nowbar](https://github.com/arian-shamaei/nowbar) — live album art for the currently playing music as a macOS menu bar item, replacing the static Now Playing glyph. Free on the App Store, open source (MIT). Placed with the other menu bar apps in System Customization, matching the existing entry format (🍎 platform + 🟢 source link).