### PR TITLE
Add: Abendrot

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,7 @@
 - [AI Dictation](https://aidictation.com) - Voice-to-text with configurable shortcuts, offline recognition on supported devices, and optional cloud transcription and cleanup. 🪟 🍎 [🟢](https://github.com/writingmate/aidictation)
 - [MacOSCleaner](https://github.com/AlexTkDev/MacOSCleaner) - macOS utility for cleaning caches, temporary files, app leftovers, and duplicate files, with disk analysis and app uninstallation. 🍎 🟢
 - [DueFlow](https://ustinian5.github.io/DueFlow/) - Local-first deadline planner that turns notes or OCR text into reverse schedules, checks risks, and exports calendar events. 🍎 [🟢](https://github.com/Ustinian5/DueFlow)
+- [Abendrot](https://abendrot.app) - Menu bar screen warmer that cuts blue light on every display with a sunset-based schedule. 🍎 [🟢](https://github.com/matthewrball/abendrot)
 
 ### Clipboard Management
 


### PR DESCRIPTION
Adds Abendrot to Utility. Redo of #270, which put it under Space Visualizer by mistake.

- Site: https://abendrot.app
- Repo: https://github.com/matthewrball/abendrot
- Free, MIT, native Swift, macOS only

Placed at the bottom of `## Utility` with the other display tools (MonitorControl, Twinkle Tray). Not requesting the ⭐ icon.