### PR TITLE
Add DBTool to Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@
 - [Beekeeper Studio](https://beekeeperstudio.io) - Modern, lightweight SQL client supporting MySQL, Postgres, SQLite, SQL Server, etc. 🪟 🍎 🐧
 - [DB Browser for SQLite](https://sqlitebrowser.org) - Visual tool for creating, browsing, and editing SQLite database files. 🪟 🍎 🐧 [🟢](https://github.com/sqlitebrowser/sqlitebrowser)
 - [DearSQL](https://dearsql.dev) - Lightweight native database client built with Dear ImGui, supporting SQL and NoSQL databases. 🪟 🍎 🐧 [🟢](https://github.com/dunkbing/dearsql)
+- [DBTool](https://codemake.co/software) - Desktop client for PostgreSQL, MySQL, MariaDB, SQLite, Oracle, and SQL Server with server-side pagination, a visual query builder, and ER diagrams. 🪟 🍎 🐧 [🟢](https://github.com/achi777/db-tool)
 
 ### Network Analysis
 


### PR DESCRIPTION
Adds **DBTool** to the bottom of Developer Tools > Database, per contributing.md.

[DBTool](https://github.com/achi777/db-tool) is a free, open-source (AGPL-3.0) desktop database client covering PostgreSQL, MySQL, MariaDB, SQLite, Oracle and Microsoft SQL Server behind one interface. Native builds for Windows, macOS (Apple Silicon and Intel) and Linux.

Relative to the clients already in the section, it covers Oracle and SQL Server, and adds true server-side pagination, a drag-to-join visual query builder that generates the `SELECT`, a visual table designer with live DDL preview, and editable ER diagrams. No telemetry and no account.

Checked against the guidelines: added at the bottom of the category, order untouched, description concise and ending with a period, platform icons plus the open-source icon linking to the repository. I did not add the recommendation star.

I am the author of this project.
