### PR TITLE
Add: capkiku

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,7 +812,7 @@
 - [Shutter](https://launchpad.net/shutter) - Feature-rich screenshot tool for Linux with an integrated editor for quick annotations. 🐧
 - [Snipaste](https://snipaste.com) - Free, Customizable, Portable snipping tool.
 - [Keyty](https://keyty.app) - Keyboard and mouse visualizer that displays your keystrokes and clicks in real time for demos, recordings, and livestreams. 🍎 [🟢](https://github.com/keytyapp/Keyty)
-- [capkiku](https://capkiku.com) - Menu-bar OCR for macOS that captures any screen region to reviewed Markdown on-device, with no account. 🍎
+- [capkiku](https://capkiku.com) - Native menu-bar region OCR via on-device Apple Vision, with review/edit, Markdown frontmatter save, and screenshot deletion. 🍎
 
 ### Space Visualizer
 

--- a/README.md
+++ b/README.md
@@ -812,6 +812,7 @@
 - [Shutter](https://launchpad.net/shutter) - Feature-rich screenshot tool for Linux with an integrated editor for quick annotations. 🐧
 - [Snipaste](https://snipaste.com) - Free, Customizable, Portable snipping tool.
 - [Keyty](https://keyty.app) - Keyboard and mouse visualizer that displays your keystrokes and clicks in real time for demos, recordings, and livestreams. 🍎 [🟢](https://github.com/keytyapp/Keyty)
+- [capkiku](https://capkiku.com) - Menu-bar OCR for macOS that captures any screen region to reviewed Markdown on-device, with no account. 🍎
 
 ### Space Visualizer
 

--- a/README.md
+++ b/README.md
@@ -812,7 +812,7 @@
 - [Shutter](https://launchpad.net/shutter) - Feature-rich screenshot tool for Linux with an integrated editor for quick annotations. 🐧
 - [Snipaste](https://snipaste.com) - Free, Customizable, Portable snipping tool.
 - [Keyty](https://keyty.app) - Keyboard and mouse visualizer that displays your keystrokes and clicks in real time for demos, recordings, and livestreams. 🍎 [🟢](https://github.com/keytyapp/Keyty)
-- [capkiku](https://capkiku.com) - Native menu-bar region OCR via on-device Apple Vision, with review/edit, Markdown frontmatter save, and screenshot deletion. 🍎
+- [capkiku](https://capkiku.com) - Turn a selected screen region into editable Markdown with on-device Apple Vision OCR. 🍎
 
 ### Space Visualizer
 


### PR DESCRIPTION
## Add: capkiku

Commit message: `Add: capkiku`

Appends [capkiku](https://capkiku.com) at the bottom of Utility → Screenshot (not re-sorted), following contributing.md.

- Apple-only (🍎)
- Closed-source freeware, so no green OSS icon
- Native macOS menu-bar region OCR via Apple Vision; review then save Markdown; no account, no upload