### PR TITLE
Add: zerosmtp-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@
 - [Nexus Shell](https://nexusshell.app/?utm_source=github&utm_medium=directory&utm_campaign=awesome-free-apps) - Native macOS SSH workspace with multi-tab terminals, dual-pane file transfer, server monitoring, and Docker controls. 🍎
 - [Atomic Agent](https://atomicagent.io) - Local-first CLI and TUI coding assistant that runs open-weight models entirely on your machine. Includes 56 built-in tools for browser, filesystem, git, memory, and vision, MCP support, and a five-layer local memory system. No account or API key required. 🪟 🍎 🐧 [🟢](https://github.com/AtomicBot-ai/atomic-agent)
 - [DSH Studio](https://github.com/Moresyl/dsh-studio) - Installs, supervises, and manages DeepSeek Harness from a cross-platform desktop interface. 🪟 🍎 🐧 [🟢](https://github.com/Moresyl/dsh-studio)
+- [zerosmtp-check](https://github.com/msgwing/ZeroSMTP/tree/main/packages/zerosmtp-check) - Checks whether outbound SMTP works from a machine, testing ports, TLS and authentication, and explains the error your mail client printed. 🪟 🍎 🐧 🟢
 
 ### API Development
 


### PR DESCRIPTION
Adds `zerosmtp-check` at the bottom of **Developer Tools**.

It checks whether outbound SMTP actually works from the machine it runs on: whether the port is reachable, whether STARTTLS or implicit TLS completes, whether the certificate verifies, and which AUTH mechanisms the server offers — against any host, not one particular provider.

It also takes an error you paste and tells you what it means. A Postfix SASL line, a Python traceback, a code off a printer panel, or `curl: (67) Login denied` — which shows none of the server's answer at all — are frequently the same refusal wearing different clothes.

Free, MIT, no account, no telemetry, and no dependencies. Runs with `npx zerosmtp-check`, so there is nothing to install.

Disclosure: I maintain it.
