### PR TITLE
Add: LeafyApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,7 +734,7 @@
 - [MacOSCleaner](https://github.com/AlexTkDev/MacOSCleaner) - macOS utility for cleaning caches, temporary files, app leftovers, and duplicate files, with disk analysis and app uninstallation. 🍎 🟢
 - [DueFlow](https://ustinian5.github.io/DueFlow/) - Local-first deadline planner that turns notes or OCR text into reverse schedules, checks risks, and exports calendar events. 🍎 [🟢](https://github.com/Ustinian5/DueFlow)
 - [Abendrot](https://abendrot.app) - Menu bar screen warmer that cuts blue light on every display with a sunset-based schedule. 🍎 [🟢](https://github.com/matthewrball/abendrot)
-- [Leafy](https://leafyapp.uk) - Menu bar vocabulary builder that reads any word on screen, saves it with the sentence around it, and quizzes you on it later. 🍎
+- [LeafyApp](https://leafyapp.uk) - Menu bar vocabulary builder that reads any word on screen, saves it with the sentence around it, and quizzes you on it later. 🍎
 
 ### Clipboard Management
 

--- a/README.md
+++ b/README.md
@@ -734,6 +734,7 @@
 - [MacOSCleaner](https://github.com/AlexTkDev/MacOSCleaner) - macOS utility for cleaning caches, temporary files, app leftovers, and duplicate files, with disk analysis and app uninstallation. 🍎 🟢
 - [DueFlow](https://ustinian5.github.io/DueFlow/) - Local-first deadline planner that turns notes or OCR text into reverse schedules, checks risks, and exports calendar events. 🍎 [🟢](https://github.com/Ustinian5/DueFlow)
 - [Abendrot](https://abendrot.app) - Menu bar screen warmer that cuts blue light on every display with a sunset-based schedule. 🍎 [🟢](https://github.com/matthewrball/abendrot)
+- [Leafy](https://leafyapp.uk) - Menu bar vocabulary builder that reads any word on screen, saves it with the sentence around it, and quizzes you on it later. 🍎
 
 ### Clipboard Management
 


### PR DESCRIPTION
Adds Leafy to the end of Utility.

A menu bar app for reading in a foreign language: a shortcut boxes any word on screen, the word is saved together with the sentence it appeared in, and saved words can be reviewed later with the word blanked out of that sentence. Because it reads the screen rather than a text selection, it also works on PDFs, scans, subtitles and images.

Free, macOS 14+, native Swift, 27 MB. Not open source, so no 🟢.

There is no language or learning category in the list, so I put it in Utility next to the other one-off tools rather than opening a new category for a single entry. Happy to move it if you prefer somewhere else.

Disclosure: I'm the developer.
