### PR TITLE
Add: Codex Quota Overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@
 - [Nexus Shell](https://nexusshell.app/?utm_source=github&utm_medium=directory&utm_campaign=awesome-free-apps) - Native macOS SSH workspace with multi-tab terminals, dual-pane file transfer, server monitoring, and Docker controls. 🍎
 - [Atomic Agent](https://atomicagent.io) - Local-first CLI and TUI coding assistant that runs open-weight models entirely on your machine. Includes 56 built-in tools for browser, filesystem, git, memory, and vision, MCP support, and a five-layer local memory system. No account or API key required. 🪟 🍎 🐧 [🟢](https://github.com/AtomicBot-ai/atomic-agent)
 - [DSH Studio](https://github.com/Moresyl/dsh-studio) - Installs, supervises, and manages DeepSeek Harness from a cross-platform desktop interface. 🪟 🍎 🐧 [🟢](https://github.com/Moresyl/dsh-studio)
+- [Codex Quota Overlay](https://github.com/cpys/codex-quota-overlay) - Windows tray overlay showing Codex Desktop quota, reset time, and reset credits. 🪟 [🟢](https://github.com/cpys/codex-quota-overlay)
 
 ### API Development
 


### PR DESCRIPTION
## Summary

- Add Codex Quota Overlay to the Developer Tools section.
- Link the public MIT repository and describe the Windows tray quota display factually.

I am the maintainer of Codex Quota Overlay and am submitting this as an independent community project. It is not affiliated with or endorsed by OpenAI. The entry follows the repository's requested format and does not change the generated filter files or table of contents.
