### PR TITLE
Add: Mobile SSH

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -180,6 +180,7 @@
 ## Developer Tools
 
 - [Termux](https://termux.dev) - Terminal emulator with Linux packages for development. 🤖 🟢
+- [Mobile SSH](https://mobile-ssh.github.io) - SSH, SFTP, and terminal client with multi-session terminals, a tmux manager, and port forwarding. 🤖 🍎
 
 ### API Development
 


### PR DESCRIPTION
## Type of change

* [x] Add a new app
* [ ] Update an existing app
* [ ] Remove an app
* [ ] Other

## App information

**App name:** Mobile SSH

**Official website:** https://mobile-ssh.github.io

**Category:** Developer Tools

<u>**Description:**</u>

SSH, SFTP, and terminal client with multi-session terminals, a tmux manager, and port forwarding.

## Platform

Select **all** that apply:

* [ ] Windows
* [ ] macOS
* [ ] Linux
* [x] Android
* [x] iOS

## Repository section

* [ ] `README.md` — Desktop app
* [x] `MOBILE.md` — Mobile app

## Availability

* [x] The app is free to use.
* [x] The app is **not** already listed in the repository.
* [x] I checked `archived.md`.

**Was this app previously archived?**

* [x] No
* [ ] Yes

## Open source

* [ ] Open source
* [x] Not open source

**Repository URL (if open source):** n/a

## Changes

**What did you change?**

Added a single entry to the bottom of the ungrouped `## Developer Tools` list in `MOBILE.md`, directly after Termux — the only other terminal app in that category. One line added, nothing else touched.

## Checklist

* [x] I added the app to the correct category.
* [x] I added it to the bottom of the category as required.
* [x] I did not reorder existing apps.
* [x] My description is concise and ends with a period.
* [x] I did not modify the table of contents.
* [x] I did not modify the `filter` folder.
* [x] I followed the repository contribution guidelines.
* [x] My commit message follows the format `Add: name`, `Update: name`, or `Remove: name`.

## Additional notes

Disclosure: I am the author. The app is free with no ads, no account, and no paid tier — every feature ships in the one app. It is closed source, so no 🟢 icon.

Also worth flagging up front: Android is currently in a Google Play closed test and iOS is a public TestFlight beta, so there is not yet a public store listing — both install links are on the website. Happy to resubmit once the store listings are public if you would rather wait for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
