### PR TITLE
Add: Frankly

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -351,6 +351,7 @@
 - [LogZero](https://logzero.app) - Privacy-first habit and health tracker with mood, medication, food, exercise, and weight logs, plus on-device correlation insights. No account, no ads, no trackers. 🍎
 - [SproutGuard](https://apps.apple.com/us/app/sproutguard-screen-time-detox/id6768664921) - Screen time blocker for adults using Apple Screen Time, with scheduled blocks, loophole-resistant website blocking, and no account or cloud. 🍎
 - [ER Wait Times Quebec](https://apps.apple.com/ca/app/er-wait-times-quebec-hospital/id6801629280) - Occupancy, waiting-room headcount and average stay for all 120 Quebec emergency rooms, refreshed every 15 minutes, with the nearest-ER math done on the phone. 🍎
+- [Frankly](https://apps.apple.com/us/app/frankly-cards-for-connection/id6784455025) - Conversation card decks for couples, friends and family, swiped one at a time with a follow-up question behind each card. Works offline, no account, answers stay on device. 🍎
 
 ## Sports
 


### PR DESCRIPTION
**Disclosure up front: I'm the developer of this app.** Submitting via PR because `contributing.md` names it as a route; happy to close this immediately if self-submissions aren't welcome here.

**Frankly: Cards for Connection** — https://apps.apple.com/us/app/frankly-cards-for-connection/id6784455025

Conversation card decks you swipe one at a time, with a follow-up question behind each card. No account, no feed, works fully offline — answers and progress stay on the device.

**Two things I want to be straight about, so you can judge rather than discover:**

1. **It's freemium, not free-forever.** Free to download, one deck free outright plus the first five cards of every other deck; beyond that there are per-deck unlocks and an optional subscription. I added it because Notion, Bear and Evernote are already on the list, so paid tiers seem to be in scope — but if the bar is stricter than I've read it, say so and I'll withdraw this.
2. **Placement is a guess.** The App Store categorises it as Lifestyle / Entertainment and `MOBILE.md` has neither, so I put it at the bottom of **Health and Wellness** as the nearest existing fit — alongside Paula, LogZero and SproutGuard, which share the local-only/no-account character. If you'd rather it went somewhere else, or nowhere, that's entirely your call and I'll move or drop it.

**Against `contributing.md`:**
- Added to the **bottom** of the specific category, order otherwise untouched
- Description is concise and feature-focused, ends with a period, doesn't start with an article
- Icons after the description: 🍎 only (iOS only; closed source, so no 🟢)
- No changes to the table of contents or anything in `filter/` — only `MOBILE.md` touched, one line
- Commit message: `Add: Frankly`