### PR TITLE
Add: AccuPDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@
 - [pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit) - PDFtk is a simple tool for doing everyday things with PDF documents. 🪟 🍎 🐧
 - [PDFluent](https://pdfluent.com/download/) - Offline PDF editor for forms, OCR, redaction, signatures, conversion, and page management on Windows and macOS. 🪟 🍎
 - [OffPDF](https://offpdf.com) - Private, offline PDF toolbox for organizing, converting, compressing, OCR, and more. 🪟 🍎 [🟢](https://github.com/McanKul/offpdf)
+- [AccuPDF](https://accupdf.com) - Browser-based PDF suite to merge, split, compress, OCR, convert, fill forms, and redact, all client-side so your files never leave your device. 🪟 🍎 🐧
 
 ## Note Taking
 


### PR DESCRIPTION
Adds [AccuPDF](https://accupdf.com) to PDF Tools — a free, browser-based PDF suite (merge, split, compress, OCR, convert, fill forms, redact) that runs entirely client-side, so files never leave the device. Runs on all desktop platforms via the browser (installable as a PWA), same as existing web-based entries like Figma. Added to the bottom of the category per contributing.md.