### PR TITLE
Add: Noctis

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,6 +692,7 @@
 - [v2rayN](https://github.com/2dust/v2rayN) - Open source GUI for Xray and Sing-box. 🪟 🍎 🐧 🟢
 - [WireGuard](https://wireguard.com) - Fast, secure VPN protocol designed for simplicity. 🪟 🍎 🐧 [🟢](https://www.wireguard.com/repositories)
 - [Tailscale](https://tailscale.com) - Mesh VPN client for secure private networks using WireGuard. 🪟 🍎 🐧
+- [Noctis](https://noctis.c0nn3ct.info) - Browser-only proxy for Chrome over VLESS Reality, VMess, Trojan, Shadowsocks, Hysteria2, TUIC or WireGuard, driven by a local sing-box, Xray or mihomo core. 🪟 🍎 🐧
 
 ## Utility
 


### PR DESCRIPTION
Noctis routes browser traffic through your own proxy server and leaves the rest of the system alone. A native helper runs a local sing-box, Xray or mihomo core, so the extension speaks VLESS and VLESS Reality, VMess, Trojan, Shadowsocks, Hysteria2, TUIC, WireGuard, AnyTLS and ShadowTLS. Per-host rules decide whether a request takes the proxy or goes direct.

- Site: https://noctis.c0nn3ct.info
- Web Store: https://chromewebstore.google.com/detail/noctis/nmhobajopepdpihahepaddpdifdcenpn
- Helper source, MIT: https://github.com/c0nn3ct-info/noctis
- Free, no account.

Added at the bottom of VPN and Proxy Tools, as the contributing guide asks, with no reordering. Platform markers are 🪟 🍎 🐧. I left the open-source marker off: the helper is MIT, the extension is not.

Disclosure: I wrote Noctis.
