### PR TITLE
Add: ER Wait Times Quebec

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -350,6 +350,7 @@
 - [Euki](https://eukiapp.org) - Privacy-first period tracker with sexual health resources and local-only data storage. 🤖 🍎 [🟢](https://github.com/Euki-Inc/Euki-Android)
 - [LogZero](https://logzero.app) - Privacy-first habit and health tracker with mood, medication, food, exercise, and weight logs, plus on-device correlation insights. No account, no ads, no trackers. 🍎
 - [SproutGuard](https://apps.apple.com/us/app/sproutguard-screen-time-detox/id6768664921) - Screen time blocker for adults using Apple Screen Time, with scheduled blocks, loophole-resistant website blocking, and no account or cloud. 🍎
+- [ER Wait Times Quebec](https://apps.apple.com/ca/app/er-wait-times-quebec-hospital/id6801629280) - Occupancy, waiting-room headcount and average stay for all 120 Quebec emergency rooms, refreshed every 15 minutes, with the nearest-ER math done on the phone. 🍎
 
 ## Sports
 


### PR DESCRIPTION
Adds the app to **Health and Wellness** in `MOBILE.md`, at the bottom of the category.

It reads Quebec's public MSSS emergency-room feed (updated every 15 minutes) and shows occupancy, waiting-room headcount and average length of stay for roughly 120 ERs. The "near me" calculation runs on the device, so location never leaves the phone.

Free with no ads. There is an optional CA$4.99/month tier that adds walk-in clinic hours and surgery waitlists; everything described in the entry is in the free app.

Disclosure: I built it.
