### PR TITLE
Add Loofah to Note Taking

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@
 - [Snoq](https://snoq.io) - Secure, offline-first note-taking app with AES-256 encryption. 🪟
 - [Knopo](https://github.com/alkalim/Knopo) - Local-first outliner for plain Markdown notes with backlinks, page/block references, and graph-friendly files. 🍎 [🟢](https://github.com/alkalim/Knopo)
 - [Bangle.io](https://bangle.io) - Local-first WYSIWYG note-taking app that keeps notes as portable Markdown files. 🪟 🍎 🐧 [🟢](https://github.com/bangle-io/bangle-io)
+- [Loofah](https://loofah.io) - Local-first meeting notetaker with on-device transcription and Markdown vault storage. 🍎 [🟢](https://github.com/bart6114/loofah)
 
 ## Text Editors
 


### PR DESCRIPTION
Adds Loofah to the Note Taking section.

Loofah is a free, MIT-licensed Mac app that records and transcribes meetings locally and keeps the resulting notes as ordinary Markdown files.

Affiliation: I'm the Loofah maintainer. This PR was prepared with an automated agent.
