### PR TITLE
Update (MOBILE): replace Simple Gallery with Fossify Gallery

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -296,7 +296,7 @@
 ## Image Viewers
 
 - [Photo Map](https://play.google.com/store/apps/details?id=com.bischofs.photoviewer) - Displays images in a map view based on geotags. 🤖
-- [Simple Gallery](https://simplemobiletools.com/gallery) - Lightweight image viewer with sorting and editing options. 🤖 🟢
+- [Fossify Gallery](https://www.fossify.org/apps/gallery) - Privacy-focused photo and video gallery with editing, metadata removal, and protected folders. 🤖 [🟢](https://github.com/FossifyOrg/Gallery)
 - [A+ Gallery](https://play.google.com/store/apps/details?id=com.atomicadd.filedir) - Organize and view photos by date, location, and albums. 🤖
 - [Google Photos](https://photos.google.com) - Manage and sync photos with powerful search and cloud backup. 🤖 🍎
 


### PR DESCRIPTION
## Summary

Resolves #285.

The currently listed Simple Gallery URL now points to the commercial successor, while the old source repository has not been updated since 2024. This replaces that entry with Fossify Gallery, the actively maintained GPL-3.0 community fork.

## Verification

- confirmed Fossify Gallery is not already listed or archived
- confirmed the repository is active, GPL-3.0 licensed, and has current releases
- linked the green icon directly to the source repository
- kept the entry in the existing mobile gallery category
- changed only MOBILE.md