### PR TITLE
Update: Make link audit reliable

### DIFF
--- a/.github/workflows/link count.yml
+++ b/.github/workflows/link count.yml
@@ -1,19 +1,28 @@
-name: Link count
+name: Link audit
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'index.js'
+      - 'tests/index.test.js'
+      - '.github/workflows/link count.yml'
 
 jobs:
-  run-node-script:
+  test-link-auditor:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
 
-      - name: Run command
-        run: node index.js --links
+      - name: Run tests
+        run: node --test tests/index.test.js
+
+      - name: Audit repository links
+        if: github.event_name == 'workflow_dispatch'
+        run: node index.js --test-links

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const { execSync, spawn } = require('child_process');
+const { execSync } = require('child_process');
 
 function create(file, fileName, emoji) {
   const startTime = Date.now();
@@ -75,8 +75,7 @@ function format(file = "README.md") {
  */
 function getLinks(file = "README.md") {
   const data = fs.readFileSync(file, "utf8");
-  const links = data.match(/\[.*?\]\(https?:\/\/.*?\)/g) || [];
-  return links.map((url) => url.split("(").at(-1).slice(0, -1));
+  return Array.from(data.matchAll(/\[[^\]]*\]\((https?:\/\/[^)\s]+)\)/g), (match) => match[1]);
 }
 
 /** Print the amount of links in a given file */
@@ -85,40 +84,48 @@ function countLinks(file = "README.md") {
   console.log(`Total links in ${file}: \x1b[32m${linkCount}\x1b[0m`);
 }
 
-/**
- * DEPENDENCY: curl
- * @param {any} url string
- * @returns {Promise} test if a given url is reachable in 3 seconds
- */
-function testUrl(url) {
-  return new Promise((resolve, reject) => {
-    const script = spawn("curl", ["-Is", "--connect-timeout", "3", url]);
-    let output = "";
-    let errorOutput = "";
-
-    script.stdout.on("data", (data) => {
-      output += data.toString();
-    });
-
-    script.stderr.on("data", (data) => {
-      errorOutput += data.toString();
-    });
-
-    script.on("close", (code) => {
-      if (code === 0) {
-        // console.log(url, "is valid");
-        resolve(output);
-      } else {
-        console.log(url, "is not reachable");
-        reject(errorOutput);
-      }
-    });
-
-    script.on("error", (err) => {
-      console.log(url, "failed to execute");
-      reject(err);
-    });
+async function testUrl(url, { fetchImpl = fetch, timeoutMs = 10000 } = {}) {
+  const request = (method) => fetchImpl(url, {
+    method,
+    redirect: "follow",
+    headers: { "user-agent": "awesome-free-apps-link-audit/1.0" },
+    signal: AbortSignal.timeout(timeoutMs),
   });
+
+  try {
+    let response = await request("HEAD");
+    if (!response.ok) {
+      response = await request("GET");
+    }
+
+    return { url, ok: response.ok, status: response.status };
+  } catch (error) {
+    return {
+      url,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function mapWithConcurrency(items, concurrency, worker) {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new TypeError("concurrency must be a positive integer");
+  }
+
+  const results = new Array(items.length);
+  let nextIndex = 0;
+
+  async function runWorker() {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      results[index] = await worker(items[index], index);
+    }
+  }
+
+  const workerCount = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, runWorker));
+  return results;
 }
 
 /**
@@ -126,25 +133,36 @@ function testUrl(url) {
  * @param {string} file
  * @returns {Promise}
  */
-function testLinksReachable(file = "README.md") {
-  console.log(`Testing links in \x1b[32m${file}\x1b[0m`);
+async function testLinksReachable(
+  file = "README.md",
+  { concurrency = 12, testUrlImpl = testUrl } = {},
+) {
+  const links = [...new Set(getLinks(file))];
+  console.log(`Testing ${links.length} unique links in \x1b[32m${file}\x1b[0m`);
 
-  const promises = getLinks(file).map(async (url) => {
-    try {
-      await testUrl(url);
-    } catch (_) {}
-  });
+  const results = await mapWithConcurrency(links, concurrency, testUrlImpl);
+  const failures = results.filter((result) => !result.ok);
 
-  return Promise.all(promises);
+  for (const failure of failures) {
+    const reason = failure.status ? `HTTP ${failure.status}` : failure.error;
+    console.error(`- ${failure.url} (${reason || "request failed"})`);
+  }
+
+  console.log(
+    `${file}: ${results.length - failures.length}/${results.length} links reachable`,
+  );
+  return { file, total: results.length, failures };
 }
 
-async function testLinksInAllFiles() {
-  try {
-    await testLinksReachable("README.md");
-    await testLinksReachable("MOBILE.md");
-  } catch (error) {
-    console.error("An error occurred:", error);
-  }
+async function testLinksInAllFiles(options) {
+  const reports = [];
+  reports.push(await testLinksReachable("README.md", options));
+  reports.push(await testLinksReachable("MOBILE.md", options));
+
+  const total = reports.reduce((sum, report) => sum + report.total, 0);
+  const failures = reports.flatMap((report) => report.failures);
+  console.log(`Link audit complete: ${total - failures.length}/${total} reachable`);
+  return { total, failures, reports };
 }
 
 
@@ -248,38 +266,57 @@ function formatFiles() {
   format("MOBILE.md");
 }
 
-const args = process.argv.slice(2);
-
-if (args.includes('--analyze')) {
-  analyze("README.md");
-  analyze("MOBILE.md");
-} else if (args.includes('--toc')) {
-  createToC();
-} else if (args.includes('--categorize')) {
-  categorize();
-} else if (args.includes('--format')) {
-  formatFiles();
-} else if (args.includes('--links')) {
-  countLinks("README.md");
-  countLinks("MOBILE.md");
-} else if (args.includes('--fastgit')) {
-  const commitMessage = args.slice(1).join(' ');
-  if (commitMessage) {
-    fastGit(commitMessage);
+function main(args = process.argv.slice(2)) {
+  if (args.includes('--analyze')) {
+    analyze("README.md");
+    analyze("MOBILE.md");
+  } else if (args.includes('--toc')) {
+    createToC();
+  } else if (args.includes('--categorize')) {
+    categorize();
+  } else if (args.includes('--format')) {
+    formatFiles();
+  } else if (args.includes('--links')) {
+    countLinks("README.md");
+    countLinks("MOBILE.md");
+  } else if (args.includes('--fastgit')) {
+    const commitMessage = args.slice(1).join(' ');
+    if (commitMessage) {
+      fastGit(commitMessage);
+    } else {
+      console.log('Please provide a commit message after --fastgit');
+    }
+  } else if (args.includes('--all')) {
+    runAll();
+  } else if (args.includes('--test-links')) {
+    testLinksInAllFiles()
+      .then(({ failures }) => {
+        if (failures.length > 0) process.exitCode = 1;
+      })
+      .catch((error) => {
+        console.error("Link audit failed:", error);
+        process.exitCode = 1;
+      });
   } else {
-    console.log('Please provide a commit message after --fastgit');
+    console.log("Usage:");
+    console.log("  node index.js --categorize     Categorize based on icons");
+    console.log("  node index.js --format         Format README.md");
+    console.log("  node index.js --links          Count and display total links in README.md");
+    console.log("  node index.js --fastgit <msg>  Run git commands with the specified commit message");
+    console.log("  node index.js --analyze        Print some info about README.md");
+    console.log("  node index.js --toc            Update the table of contents");
+    console.log("  node index.js --all            Run all the commands (format, categorize, links)");
   }
-} else if (args.includes('--all')) {
-  runAll();
-} else if (args.includes('--test-links')) {
-  testLinksInAllFiles()
-} else {
-  console.log("Usage:");
-  console.log("  node index.js --categorize     Categorize based on icons");
-  console.log("  node index.js --format         Format README.md");
-  console.log("  node index.js --links          Count and display total links in README.md");
-  console.log("  node index.js --fastgit <msg>  Run git commands with the specified commit message");
-  console.log("  node index.js --analyze        Print some info about README.md");
-  console.log("  node index.js --toc            Update the table of contents");
-  console.log("  node index.js --all            Run all the commands (format, categorize, links)");
 }
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  getLinks,
+  mapWithConcurrency,
+  testLinksInAllFiles,
+  testLinksReachable,
+  testUrl,
+};

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,0 +1,116 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const http = require("node:http");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  getLinks,
+  mapWithConcurrency,
+  testLinksReachable,
+  testUrl,
+} = require("../index.js");
+
+test("getLinks extracts HTTP links without surrounding Markdown", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "afa-links-"));
+  const file = path.join(directory, "README.md");
+  fs.writeFileSync(
+    file,
+    [
+      "[One](https://example.com/one)",
+      "[Two](http://example.test/two)",
+      "![Local](./logo.svg)",
+    ].join("\n"),
+  );
+
+  try {
+    assert.deepEqual(getLinks(file), [
+      "https://example.com/one",
+      "http://example.test/two",
+    ]);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("testUrl follows redirects, rejects HTTP errors, and retries failed HEAD requests", async (t) => {
+  const server = http.createServer((request, response) => {
+    if (request.url === "/redirect") {
+      response.writeHead(302, { location: "/ok" }).end();
+    } else if (request.url === "/head-unsupported" && request.method === "HEAD") {
+      response.writeHead(405).end();
+    } else if (request.url === "/missing") {
+      response.writeHead(404).end();
+    } else {
+      response.writeHead(200).end("ok");
+    }
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  assert.deepEqual(await testUrl(`${baseUrl}/redirect`), {
+    url: `${baseUrl}/redirect`,
+    ok: true,
+    status: 200,
+  });
+  assert.deepEqual(await testUrl(`${baseUrl}/head-unsupported`), {
+    url: `${baseUrl}/head-unsupported`,
+    ok: true,
+    status: 200,
+  });
+  assert.deepEqual(await testUrl(`${baseUrl}/missing`), {
+    url: `${baseUrl}/missing`,
+    ok: false,
+    status: 404,
+  });
+});
+
+test("mapWithConcurrency never exceeds its worker limit", async () => {
+  let active = 0;
+  let maximum = 0;
+  const results = await mapWithConcurrency([1, 2, 3, 4, 5], 2, async (value) => {
+    active += 1;
+    maximum = Math.max(maximum, active);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    active -= 1;
+    return value * 2;
+  });
+
+  assert.deepEqual(results, [2, 4, 6, 8, 10]);
+  assert.equal(maximum, 2);
+});
+
+test("testLinksReachable deduplicates links and reports failures", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "afa-audit-"));
+  const file = path.join(directory, "README.md");
+  fs.writeFileSync(
+    file,
+    [
+      "[One](https://example.com/ok)",
+      "[Duplicate](https://example.com/ok)",
+      "[Broken](https://example.com/missing)",
+    ].join("\n"),
+  );
+
+  try {
+    const report = await testLinksReachable(file, {
+      concurrency: 1,
+      testUrlImpl: async (url) => ({
+        url,
+        ok: !url.endsWith("/missing"),
+        status: url.endsWith("/missing") ? 404 : 200,
+      }),
+    });
+
+    assert.equal(report.total, 2);
+    assert.deepEqual(report.failures, [
+      { url: "https://example.com/missing", ok: false, status: 404 },
+    ]);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

The existing `--test-links` command only checked whether `curl` launched successfully. HTTP 404 and 500 responses were treated as reachable, all requests ran at once, individual failures were swallowed, and the command still exited successfully.

## Changes

- use Node's built-in `fetch`, removing the external curl dependency
- follow redirects and retry failed HEAD requests with GET
- deduplicate links and cap request concurrency
- aggregate HTTP and network failures with a non-zero exit status
- add focused Node tests for parsing, redirects, HTTP failures, fallback behavior, deduplication, and concurrency
- update the manual workflow to current action versions and run the test suite on relevant pull requests

## Validation

- `node --test tests/index.test.js` (4 passed)
- `node --check index.js`
- `node index.js --links` (758 README links, 175 mobile links)
- full manual audit completed: 832/900 unique links reachable; 68 were reported for separate content review rather than changed in this PR