### PR TITLE
Add: BlockMosaic

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@
 - [Affinity](https://www.affinity.studio/) - Professional creative suite for photo editing, graphic design, and desktop publishing. 🪟 🍎
 - [Open Photo AI](https://github.com/vegidio/open-photo-ai) - An open source alternative to the popular photo AI editor. 🪟 🍎 🐧 🟢
 - [ItsPaint](https://itspaintmac.com/) - MS Paint for macOS: blank canvas at any size, paste one image onto another, crop, and mark up screenshots. 🍎 🟢
+- [BlockMosaic](https://mcimagetool.com) - Convert images into buildable Minecraft pixel art with block counts and schematic export. 🪟 🍎 🐧
 
 ## 3D Modeling and Animation
 


### PR DESCRIPTION
## Summary
Resolves #269.

Adds BlockMosaic (free browser-based Minecraft pixel art and schematic generator) to the Graphics Tools section.

## Verification
- Verified official website https://mcimagetool.com returns HTTP 200
- Tested no signup or payment required
- Adheres to contribution format and placement rules
- Tests pass: node --test tests/index.test.js