### PR TITLE
Add: SoulSync

### DIFF
--- a/MOBILE.md
+++ b/MOBILE.md
@@ -355,6 +355,7 @@
 - [LogZero](https://logzero.app) - Privacy-first habit and health tracker with mood, medication, food, exercise, and weight logs, plus on-device correlation insights. No account, no ads, no trackers. 🍎
 - [SproutGuard](https://apps.apple.com/us/app/sproutguard-screen-time-detox/id6768664921) - Screen time blocker for adults using Apple Screen Time, with scheduled blocks, loophole-resistant website blocking, and no account or cloud. 🍎
 - [ER Wait Times Quebec](https://apps.apple.com/ca/app/er-wait-times-quebec-hospital/id6801629280) - Occupancy, waiting-room headcount and average stay for all 120 Quebec emergency rooms, refreshed every 15 minutes, with the nearest-ER math done on the phone. 🍎
+- [SoulSync](https://play.google.com/store/apps/details?id=com.raeduslabs.soulsyncapp) - Private, offline mood tracker with a 10-point mood scale, activity correlation stats, and plain-language insights. No account, no ads, no analytics. 🤖 [🟢](https://github.com/Antimatter543/mood-tracker)
 
 ## Sports
 


### PR DESCRIPTION
Adds SoulSync to Health and Wellness (mobile list).

Private, offline mood tracker for Android: 10-point mood scale, activity correlation stats, plain-language insights. No account, no ads, no analytics. Open source (GPL-3.0).

- Play Store: https://play.google.com/store/apps/details?id=com.raeduslabs.soulsyncapp
- Source: https://github.com/Antimatter543/mood-tracker