### PR TITLE
Add: Focuh

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,7 @@
 - [DueFlow](https://ustinian5.github.io/DueFlow/) - Local-first deadline planner that turns notes or OCR text into reverse schedules, checks risks, and exports calendar events. 🍎 [🟢](https://github.com/Ustinian5/DueFlow)
 - [Abendrot](https://abendrot.app) - Menu bar screen warmer that cuts blue light on every display with a sunset-based schedule. 🍎 [🟢](https://github.com/matthewrball/abendrot)
 - [LeafyApp](https://leafyapp.uk) - Menu bar vocabulary builder that reads any word on screen, saves it with the sentence around it, and quizzes you on it later. 🍎
+- [Focuh](https://www.focuh.com) - Free ADHD Mac todo list and week planner with a focus timer and system-wide website/app blocking. 🍎
 
 ### Clipboard Management
 


### PR DESCRIPTION
## Summary
Adds [Focuh](https://www.focuh.com) to **Utility** (bottom of the main Utility list, after LeafyApp).

Focuh is a free ADHD todo list and week planner for Mac with a focus timer and system-wide website/app blocking. Signed and notarized; Apple Silicon + Intel. Also has a web app.

I am the developer.

## Checklist
- [x] Added to the bottom of the category (not reordered)
- [x] Concise feature description ending in a period
- [x] Description does not start with A/An/The
- [x] Platform emoji after description (`🍎`)
- [x] No TOC / filter folder edits
- [x] Commit message: `Add: Focuh`