### PR TITLE
Mark Beetroot as open-source

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,7 +748,7 @@
 
 ### Clipboard Management
 
-- [Beetroot](https://max.nardit.com/beetroot) - Clipboard manager with AI text transforms and OCR extraction. 🪟
+- [Beetroot](https://max.nardit.com/beetroot) - Clipboard manager with AI text transforms and OCR extraction. 🪟 [🟢](https://github.com/mnardit/beetroot-releases)
 - [ClipAngel](https://sourceforge.net/projects/clip-angel) - Clipboard manager supporting rich text and images. 🪟
 - [Clipboard Fusion](https://clipboardfusion.com) - Clipboard manager with data transformation features. 🪟 🍎
 - [Clipy](https://clipy-app.com) - Simple clipboard manager. 🍎 🟢


### PR DESCRIPTION
Beetroot is now open source (Apache-2.0). Adding the 🟢 open-source marker (linked to the source repo) to my existing entry under Clipboard Management. Source: https://github.com/mnardit/beetroot-releases — README.md only, position unchanged, filter/ untouched.