### PR TITLE
Add: LibreDB Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@
 - [DB Browser for SQLite](https://sqlitebrowser.org) - Visual tool for creating, browsing, and editing SQLite database files. 🪟 🍎 🐧 [🟢](https://github.com/sqlitebrowser/sqlitebrowser)
 - [DearSQL](https://dearsql.dev) - Lightweight native database client built with Dear ImGui, supporting SQL and NoSQL databases. 🪟 🍎 🐧 [🟢](https://github.com/dunkbing/dearsql)
 - [DBTool](https://codemake.co/software) - Desktop client for PostgreSQL, MySQL, MariaDB, SQLite, Oracle, and SQL Server with server-side pagination, a visual query builder, and ER diagrams. 🪟 🍎 🐧 [🟢](https://github.com/achi777/db-tool)
+- [LibreDB Studio](https://libredb.org) - Database client for PostgreSQL, MySQL, Oracle, SQL Server, MongoDB, Redis and ten other SQL and NoSQL engines, with single sign-on and a query audit trail. 🪟 🍎 🐧 [🟢](https://github.com/libredb/libredb-studio)
 
 ### Network Analysis
 


### PR DESCRIPTION
## Type of change

* [x] Add a new app
* [ ] Update an existing app
* [ ] Remove an app
* [ ] Other

## App information

**App name:** LibreDB Studio

**Official website:** https://libredb.org

**Category:** Developer Tools / Database

<u>**Description:**</u>

Database client for PostgreSQL, MySQL, Oracle, SQL Server, MongoDB, Redis and ten other SQL and NoSQL engines, with single sign-on and a query audit trail.

## Platform

Select **all** that apply:

* [ ] Windows
* [ ] macOS
* [x] Linux
* [ ] Android
* [ ] iOS

## Repository section

* [x] `README.md` — Desktop app
* [ ] `MOBILE.md` — Mobile app

## Availability

* [x] The app is free to use.
* [x] The app is **not** already listed in the repository.
* [x] I checked `archived.md`.

**Was this app previously archived?**

* [x] No
* [ ] Yes

**If the app was previously archived, please explain why it should be restored:**

Not applicable.

## Open source

* [x] Open source
* [ ] Not open source

**Repository URL (if open source):** https://github.com/libredb/libredb-studio

## Changes

**What did you change?**

I added one line for LibreDB Studio at the bottom of the Database list in `README.md`. Nothing else was touched.

## Checklist

* [x] I added the app to the correct category.
* [x] I added it to the bottom of the category as required.
* [x] I did not reorder existing apps.
* [x] My description is concise and ends with a period.
* [x] I did not modify the table of contents.
* [x] I did not modify the `filter` folder.
* [x] I followed the repository contribution guidelines.
* [x] My commit message follows the format `Add: name`, `Update: name`, or `Remove: name`.

## Additional notes

About the three platform boxes, I would rather be straight with you than have you find it later. The desktop build is Linux only, shipped as AppImage and deb. On Windows and macOS you run the server yourself and use it in the browser, and the packages for that path are on winget, Chocolatey, Homebrew, Snap and npm. So the app is usable on all three systems, but only Linux gets a desktop bundle. If you would rather the entry showed Linux alone, say so and I will change it.

It is MIT licensed and version 0.15.0 is current. Single sign-on through OIDC and the query audit trail are both in the MIT build, not held back for a paid tier.